### PR TITLE
Simplify the matching regex, and make it easier to add ignored terms or collective nouns

### DIFF
--- a/scripts/guys-bot.js
+++ b/scripts/guys-bot.js
@@ -10,6 +10,8 @@ const phrasesToIgnore = [
   /guy(s|z)bot(s|z)?/gi,
 ];
 
+const collectiveNouns = ["fellow kids", "folks", "humans", "people", `y'all`];
+
 module.exports = (robot) => {
   const { addEmojiReaction, postEphemeralMessage } = utils.setup(robot);
 
@@ -25,11 +27,14 @@ module.exports = (robot) => {
 
     addEmojiReaction("inclusion-bot", msg.message.room, msg.message.id);
 
+    const noun =
+      collectiveNouns[Math.floor(Math.random() * collectiveNouns.length)];
+
     postEphemeralMessage({
       attachments: [
         {
           color: "#2eb886",
-          pretext: `Did you mean *y'all*? (_<https://web.archive.org/web/20170714141744/https://18f.gsa.gov/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/|What's this?>_)`,
+          pretext: `Did you mean *${noun}*? (_<https://web.archive.org/web/20170714141744/https://18f.gsa.gov/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/|What's this?>_)`,
           text: `Hello! Our inclusive TTS culture is built one interaction at a time, and inclusive language is the foundation. Instead of guys, we encourage everyone to try out a new phrase to describe multiple people. This is a small way we build inclusion into our everyday work lives.          `,
           fallback: `Hello! Our inclusive TTS culture is built one interaction at a time, and inclusive language is the foundation. Instead of guys, we encourage everyone to try out a new phrase to describe multiple people. This is a small way we build inclusion into our everyday work lives.`,
         },

--- a/scripts/guys-bot.js
+++ b/scripts/guys-bot.js
@@ -10,14 +10,7 @@ const phrasesToIgnore = [
   /guy(s|z)bot(s|z)?/gi,
 ];
 
-const collectiveNouns = [
-  "fellow kids",
-  "folks",
-  "friends",
-  "people",
-  "team",
-  `y'all`,
-];
+const collectiveNouns = ["folks", "friends", "people", "team", `y'all`];
 
 module.exports = (robot) => {
   const { addEmojiReaction, postEphemeralMessage } = utils.setup(robot);

--- a/scripts/guys-bot.js
+++ b/scripts/guys-bot.js
@@ -1,12 +1,25 @@
 const utils = require("../utils");
 
-const guysRegex = /(?<!boba )(?<!five )(?<!5 )(?<!halal )guy(s|z)(?=[^"“”']*(["“”'][^"“”']*["“”'][^"“”']*)*$)/i;
+const guysRegex = /guy(s|z)(?=[^"“”']*(["“”'][^"“”']*["“”'][^"“”']*)*$)/i;
+
+const phrasesToIgnore = [
+  /boba guy(s|z)/gi,
+  /(five|5) guy(s|z)/gi,
+  /halal guy(s|z)/gi,
+  /guy(s|z) bot/gi,
+  /guy(s|z)bot(s|z)?/gi,
+];
 
 module.exports = (robot) => {
   const { addEmojiReaction, postEphemeralMessage } = utils.setup(robot);
 
   robot.hear(/guy[sz]/i, (msg) => {
-    if (!guysRegex.test(msg.message.text)) {
+    const preprocessed = phrasesToIgnore.reduce(
+      (str, ignore) => str.replace(ignore, ""),
+      msg.message.text
+    );
+
+    if (!guysRegex.test(preprocessed)) {
       return;
     }
 

--- a/scripts/guys-bot.js
+++ b/scripts/guys-bot.js
@@ -10,7 +10,14 @@ const phrasesToIgnore = [
   /guy(s|z)bot(s|z)?/gi,
 ];
 
-const collectiveNouns = ["fellow kids", "folks", "humans", "people", `y'all`];
+const collectiveNouns = [
+  "fellow kids",
+  "folks",
+  "friends",
+  "people",
+  "team",
+  `y'all`,
+];
 
 module.exports = (robot) => {
   const { addEmojiReaction, postEphemeralMessage } = utils.setup(robot);

--- a/test/scripts/guys-bot.js
+++ b/test/scripts/guys-bot.js
@@ -49,7 +49,7 @@ describe("Inclusion/guys bot", () => {
       attachments: [
         {
           color: "#2eb886",
-          pretext: `Did you mean *y'all*? (_<https://web.archive.org/web/20170714141744/https://18f.gsa.gov/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/|What's this?>_)`,
+          pretext: sinon.match.string, // `Did you mean *y'all*? (_<https://web.archive.org/web/20170714141744/https://18f.gsa.gov/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/|What's this?>_)`,
           text: `Hello! Our inclusive TTS culture is built one interaction at a time, and inclusive language is the foundation. Instead of guys, we encourage everyone to try out a new phrase to describe multiple people. This is a small way we build inclusion into our everyday work lives.          `,
           fallback: `Hello! Our inclusive TTS culture is built one interaction at a time, and inclusive language is the foundation. Instead of guys, we encourage everyone to try out a new phrase to describe multiple people. This is a small way we build inclusion into our everyday work lives.`,
         },

--- a/test/scripts/guys-bot.js
+++ b/test/scripts/guys-bot.js
@@ -119,6 +119,28 @@ describe("Inclusion/guys bot", () => {
       expect(addEmojiReaction.called).to.equal(false);
     });
 
+    it("does not respond to guysbot", () => {
+      msg.message.text = "this is about the guys bot itself";
+      handler(msg);
+      expect(postEphemeralMessage.called).to.equal(false);
+      expect(addEmojiReaction.called).to.equal(false);
+
+      msg.message.text = "this is about the guyz bot itself";
+      handler(msg);
+      expect(postEphemeralMessage.called).to.equal(false);
+      expect(addEmojiReaction.called).to.equal(false);
+
+      msg.message.text = "this is about the guysbot itself";
+      handler(msg);
+      expect(postEphemeralMessage.called).to.equal(false);
+      expect(addEmojiReaction.called).to.equal(false);
+
+      msg.message.text = "this is about the guyzbot itself";
+      handler(msg);
+      expect(postEphemeralMessage.called).to.equal(false);
+      expect(addEmojiReaction.called).to.equal(false);
+    });
+
     it("does respond to just guys", () => {
       msg.message.text = "hello guys";
       handler(msg);


### PR DESCRIPTION
- Instead of a single, complicated regex that also includes all the terms that should be ignored (e.g., "boba guys"), this change first removes ignored phrases from the message before applying the regex. This makes it easier to follow the flow of logic and makes the regex a bit easier to understand.
- Extracts the list of ignored phrases into a list so it's easier to change later.
- Switches to randomly picking a collective noun instead of always saying `y'all`, and pulls that list out so it's easier to update.

The list of potential collective nouns:
- fellow kids
- folks
- friends
- people
- team
- y'all