### PR TITLE
Update inclusion-bot.yaml to suggest alternatives to 'blind leading the blind'

### DIFF
--- a/scripts/inclusion-bot.yaml
+++ b/scripts/inclusion-bot.yaml
@@ -63,6 +63,14 @@ triggers:
       - unaware of
       - ignoring
       - not paying attention to
+      
+  - matches:
+      - blind leading the blind
+    alternatives:
+      - winging it
+      - feeling around in the dark
+      - building the airplane while we fly it
+      - finding our way together
 
   - matches:
       - crazy


### PR DESCRIPTION
`blind leading the blind` is an idiom used to describe a situation where people who don't know what they're doing are being directed by people who don't know what they're doing, and is a terrible and incorrect association to make with people who don't have eyesight.