### PR TITLE
Coffeemate-bot scopes

### DIFF
--- a/src/scripts/coffeemate.js
+++ b/src/scripts/coffeemate.js
@@ -12,9 +12,12 @@ const baseResponse = {
 };
 
 module.exports = (app) => {
-  app.message(/coffee me( .+)?/i, async (message) => {
+  app.message(/coffee me( \S+$)?/i, async (message) => {
     const [, scopeMatch] = message.context.matches;
-    const scope = scopeMatch ? scopeMatch.trim().toLowerCase() : "";
+    const scope = (() => {
+      const out = scopeMatch ? scopeMatch.trim().toLowerCase() : "";
+      return out === "please" ? "" : out;
+    })();
 
     const key = `${brainKey}${scope}`;
     const queue = app.brain.get(key) || [];

--- a/src/scripts/coffeemate.test.js
+++ b/src/scripts/coffeemate.test.js
@@ -18,7 +18,7 @@ describe("coffeemate", () => {
     coffeemate(app);
 
     expect(app.message).toHaveBeenCalledWith(
-      /coffee me( .+)?/i,
+      /coffee me( \S+$)?/i,
       expect.any(Function)
     );
   });
@@ -89,6 +89,19 @@ describe("coffeemate", () => {
         icon_emoji: ":coffee:",
         text:
           "You’re already in the test scope queue. As soon as we find someone else to meet with, we’ll introduce you!",
+        username: "Coffeemate",
+      });
+    });
+
+    it("sends an ephemeral message subsequent times a user asks for coffee, but does not acknowledge 'please' as a scope", async () => {
+      message.context.matches = [null, " please"];
+      await handler(message);
+
+      expect(addEmojiReaction).toHaveBeenCalledWith(message, "coffee");
+      expect(postEphemeralResponse).toHaveBeenCalledWith(message, {
+        icon_emoji: ":coffee:",
+        text:
+          "You’re already in the queue. As soon as we find someone else to meet with, we’ll introduce you!",
         username: "Coffeemate",
       });
     });

--- a/src/scripts/coffeemate.test.js
+++ b/src/scripts/coffeemate.test.js
@@ -14,23 +14,20 @@ describe("coffeemate", () => {
     jest.resetAllMocks();
   });
 
-  it('subscribes to "coffee me" messages and loads the existing queue from the brain', () => {
-    const brainSpy = jest.spyOn(app.brain, "get").mockReturnValue();
-
+  it('subscribes to "coffee me" messages', () => {
     coffeemate(app);
 
     expect(app.message).toHaveBeenCalledWith(
-      /coffee me/i,
+      /coffee me( .+)?/i,
       expect.any(Function)
     );
-    expect(app.brain.get).toHaveBeenCalledWith("coffeemate_queue");
-    brainSpy.mockRestore();
   });
 
-  describe("when the coffee queue is initially empty", () => {
+  describe("with an the coffee queue is initially empty", () => {
     let handler;
 
     const message = {
+      context: { matches: [] },
       event: {
         user: "user id 1",
       },
@@ -41,6 +38,7 @@ describe("coffeemate", () => {
     });
 
     beforeEach(() => {
+      message.context.matches = [];
       coffeemate(app);
       handler = app.getHandler();
     });
@@ -65,6 +63,32 @@ describe("coffeemate", () => {
         icon_emoji: ":coffee:",
         text:
           "You’re already in the queue. As soon as we find someone else to meet with, we’ll introduce you!",
+        username: "Coffeemate",
+      });
+    });
+
+    it("sends an ephemeral message the first time a user asks for a coffee in a different scope", async () => {
+      message.context.matches = [null, " test scope"];
+      await handler(message);
+
+      expect(addEmojiReaction).toHaveBeenCalledWith(message, "coffee");
+      expect(postEphemeralResponse).toHaveBeenCalledWith(message, {
+        icon_emoji: ":coffee:",
+        text:
+          "You’re in line for test scope coffee! You’ll be introduced to the next person who wants to meet up.",
+        username: "Coffeemate",
+      });
+    });
+
+    it("sends an ephemeral message subsequent times a user asks for coffee in the same scope", async () => {
+      message.context.matches = [null, " test scope"];
+      await handler(message);
+
+      expect(addEmojiReaction).toHaveBeenCalledWith(message, "coffee");
+      expect(postEphemeralResponse).toHaveBeenCalledWith(message, {
+        icon_emoji: ":coffee:",
+        text:
+          "You’re already in the test scope queue. As soon as we find someone else to meet with, we’ll introduce you!",
         username: "Coffeemate",
       });
     });


### PR DESCRIPTION
Allow `coffee me` requests to be scoped. Scopes are a single word after `coffee me`, and people will only be matched with others who request coffee from the same scope. Hopefully the screenshot below demonstrates:

![Screenshot showing scoping of coffee me requests](https://user-images.githubusercontent.com/1775733/109569109-86892d80-7aad-11eb-8fa6-4bffffa590aa.png)

Closes #274 