### PR TITLE
Minor test cleanup

### DIFF
--- a/src/scripts/erg-inviter.test.js
+++ b/src/scripts/erg-inviter.test.js
@@ -43,8 +43,7 @@ describe("ERG inviter", () => {
 
     it("sends a message to the appropriate channel when a user requests an invitation", async () => {
       bot(app);
-      // TODO: Update the test utils to allow getting action handlers
-      const handler = app.action.mock.calls[0][1];
+      const handler = app.getActionHandler();
       const ack = jest.fn().mockResolvedValue();
 
       await handler({

--- a/src/scripts/opt-out.test.js
+++ b/src/scripts/opt-out.test.js
@@ -5,8 +5,7 @@ describe("opt-out generic action", () => {
   const app = getApp();
   optOut(app);
 
-  // TODO: Update the test utils to allow getting action handlers
-  const handler = app.action.mock.calls[0][1];
+  const handler = app.getActionHandler();
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -20,16 +20,27 @@ module.exports = {
       message,
 
       /**
+       * Get the action handler that the bot registers.
+       * @param {Number} index Optional. The index of the handler to fetch. For
+       *    Bots that register multiple handlers. This is in the order that the
+       *    handlers are registered. Defaults to 0, the first handler.
+       */
+      getActionHandler: (index = 0) => {
+        if (action.mock.calls.length > index) {
+          return action.mock.calls[index].slice(-1).pop();
+        }
+        return null;
+      },
+
+      /**
        * Get the handler that the bot registers.
        * @param {Number} index Optional. The index of the handler to fetch. For
        *    Bots that register multiple handlers. This is in the order that the
        *    handlers are registered. Defaults to 0, the first handler.
        */
       getHandler: (index = 0) => {
-        if (message.mock.calls.length > 0) {
-          return message.mock.calls[index][
-            message.mock.calls[index].length - 1
-          ];
+        if (message.mock.calls.length > index) {
+          return message.mock.calls[index].slice(-1).pop();
         }
         return null;
       },


### PR DESCRIPTION
Two recent additions both implemented a bit of logic for accessing an action handler for testing. This PR pulls that into the test utilities instead, and tidies up how the test utility gets the handler out of the array a bit.