### PR TITLE
Pugs!

### DIFF
--- a/src/scripts/pugs.js
+++ b/src/scripts/pugs.js
@@ -1,0 +1,43 @@
+const { directMention } = require("@slack/bolt");
+
+const pugs = [
+  "https://i.imgur.com/kXngLij.png",
+  "https://i.imgur.com/3wR2qg8.jpg",
+  "https://i.imgur.com/vMnlr1D.png",
+  "https://i.imgur.com/Fhhg2D4.png",
+  "https://i.imgur.com/LxVSPck.png",
+  "https://i.imgur.com/Fihh8o1.png",
+  "https://i.imgur.com/jUzKI5Z.png",
+  "https://i.imgur.com/x8VRFM1.png",
+  "https://i.imgur.com/dpM7RQU.png",
+  "https://i.imgur.com/zUN5r5p.png", // 10
+  "https://i.imgur.com/Z6CRlh1.png",
+  "https://i.imgur.com/3zXJqqU.png",
+  "https://i.imgur.com/Ok7I6H2.png",
+  "https://i.imgur.com/7Rn8WGV.png",
+  "https://i.imgur.com/8b7dm9l.png", // 15
+  "https://i.imgur.com/2NmdgpY.png",
+  "https://i.imgur.com/WtjRob1.png",
+  "https://i.imgur.com/9EFvd5s.png",
+  "https://i.imgur.com/G27DsB2.png",
+  "https://i.imgur.com/Jy2ssIK.png",
+];
+
+const makePugs = (count = 1) =>
+  [...Array(count)].map(() => ({
+    type: "image",
+    title: { type: "plain_text", text: "a pug!" },
+    image_url: pugs[Math.floor(Math.random() * pugs.length)],
+    alt_text: "a pug",
+  }));
+
+module.exports = (app) => {
+  app.message(directMention(), /pug me/i, async ({ say }) => {
+    say({ blocks: makePugs() });
+  });
+
+  app.message(directMention(), /pug bomb ?(\d+)?/i, ({ context, say }) => {
+    const count = +context.matches[1] || 3;
+    say({ blocks: makePugs(count) });
+  });
+};

--- a/src/scripts/pugs.test.js
+++ b/src/scripts/pugs.test.js
@@ -1,0 +1,155 @@
+const { getApp } = require("../utils/test");
+
+const script = require("./pugs");
+
+describe("pug bot", () => {
+  const app = getApp();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("registers message handlers", () => {
+    it("for a single pug", () => {
+      script(app);
+      expect(app.message).toHaveBeenCalledWith(
+        expect.any(Function),
+        /pug me/i,
+        expect.any(Function)
+      );
+    });
+
+    it("for multiple pugs", () => {
+      script(app);
+      expect(app.message).toHaveBeenCalledWith(
+        expect.any(Function),
+        /pug bomb ?(\d+)?/i,
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe("handles pug requests", () => {
+    it("for a single pug", () => {
+      script(app);
+      const handler = app.getHandler(0);
+      const say = jest.fn();
+
+      handler({ say });
+
+      expect(say).toHaveBeenCalledWith({
+        blocks: [
+          {
+            type: "image",
+            title: { type: "plain_text", text: "a pug!" },
+            image_url: expect.stringMatching(
+              /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+            ),
+            alt_text: "a pug",
+          },
+        ],
+      });
+    });
+
+    describe("for multiple pugs", () => {
+      const say = jest.fn();
+
+      let handler;
+      beforeEach(() => {
+        script(app);
+        handler = app.getHandler(1);
+      });
+
+      it("if the count is provided, uses the count", () => {
+        handler({ context: { matches: [null, 2] }, say });
+
+        expect(say).toHaveBeenCalledWith({
+          blocks: [
+            {
+              type: "image",
+              title: { type: "plain_text", text: "a pug!" },
+              image_url: expect.stringMatching(
+                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+              ),
+              alt_text: "a pug",
+            },
+            {
+              type: "image",
+              title: { type: "plain_text", text: "a pug!" },
+              image_url: expect.stringMatching(
+                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+              ),
+              alt_text: "a pug",
+            },
+          ],
+        });
+      });
+
+      it("if the count is not provided, defaults to 3", () => {
+        handler({ context: { matches: [null] }, say });
+
+        expect(say).toHaveBeenCalledWith({
+          blocks: [
+            {
+              type: "image",
+              title: { type: "plain_text", text: "a pug!" },
+              image_url: expect.stringMatching(
+                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+              ),
+              alt_text: "a pug",
+            },
+            {
+              type: "image",
+              title: { type: "plain_text", text: "a pug!" },
+              image_url: expect.stringMatching(
+                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+              ),
+              alt_text: "a pug",
+            },
+            {
+              type: "image",
+              title: { type: "plain_text", text: "a pug!" },
+              image_url: expect.stringMatching(
+                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+              ),
+              alt_text: "a pug",
+            },
+          ],
+        });
+      });
+
+      it("if the count is provided but is not numeric, defaults to 3", () => {
+        handler({ context: { matches: [null, "bob"] }, say });
+
+        expect(say).toHaveBeenCalledWith({
+          blocks: [
+            {
+              type: "image",
+              title: { type: "plain_text", text: "a pug!" },
+              image_url: expect.stringMatching(
+                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+              ),
+              alt_text: "a pug",
+            },
+            {
+              type: "image",
+              title: { type: "plain_text", text: "a pug!" },
+              image_url: expect.stringMatching(
+                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+              ),
+              alt_text: "a pug",
+            },
+            {
+              type: "image",
+              title: { type: "plain_text", text: "a pug!" },
+              image_url: expect.stringMatching(
+                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+              ),
+              alt_text: "a pug",
+            },
+          ],
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds `pug me` and `pug bomb #` commands to the bot. Has one big shortcoming in that the list of pug images is hardcoded, but that seems like a reasonable temporary shortcoming that we can deal with later.

- closes #270