### PR TITLE
Implement Handbot, the TTS Handbook search helper

### DIFF
--- a/src/scripts/handbot.js
+++ b/src/scripts/handbot.js
@@ -1,0 +1,78 @@
+const axios = require("axios");
+const {
+  slack: { postEphemeralResponse },
+} = require("../utils");
+
+const baseUrl =
+  "https://search.usa.gov/search/?utf8=no&affiliate=tts-handbook&format=json&query=";
+
+module.exports = (app) => {
+  app.message(/@?handbo(ok|t) (.+)$/i, async (msg) => {
+    const {
+      context: {
+        matches: [, , search],
+      },
+      event: { thread_ts: thread, ts },
+      say,
+    } = msg;
+
+    const searchString = search
+      .replace(/[”“]/g, '"') // replace smart quotes
+      .replace(/[’‘]/g, "'"); // more smart quotes
+    const url = `${baseUrl}${encodeURIComponent(searchString)}`;
+
+    try {
+      const { data } = await axios.get(url);
+      const results = data.results.slice(0, 3);
+
+      if (results.length === 0) {
+        say({
+          icon_emoji: ":tts:",
+          username: "TTS Handbot",
+          thread_ts: thread || ts,
+          text: `I couldn't find any results for "${searchString}"`,
+        });
+      } else {
+        say({
+          icon_emoji: ":tts:",
+          username: "TTS Handbot",
+          thread_ts: thread || ts,
+          blocks: [
+            {
+              type: "header",
+              text: {
+                type: "plain_text",
+                text: `Handbook search results for "${searchString}"`,
+              },
+            },
+            ...results.reduce((blocks, result) => {
+              blocks.push({ type: "divider" });
+              blocks.push({
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: `<${result.link}|${result.title.replace(
+                    /[^ -~]+/g,
+                    ""
+                  )}>\n${result.body.replace(/[^ -~]+/g, "")}`,
+                },
+              });
+              blocks.push({
+                type: "context",
+                elements: [{ type: "mrkdwn", text: result.link }],
+              });
+              return blocks;
+            }, []),
+          ],
+        });
+      }
+    } catch (e) {
+      postEphemeralResponse(msg, {
+        icon_emoji: ":tts:",
+        username: "TTS Handbot",
+        text:
+          "Something went wrong trying to search the Handbook. Please try later!",
+      });
+    }
+  });
+};

--- a/src/scripts/handbot.test.js
+++ b/src/scripts/handbot.test.js
@@ -1,0 +1,231 @@
+const {
+  axios,
+  getApp,
+  utils: {
+    slack: { postEphemeralResponse },
+  },
+} = require("../utils/test");
+const handbot = require("./handbot");
+
+describe("TTS Handbook search (Handbot)", () => {
+  const app = getApp();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("subscribes to the right message", () => {
+    handbot(app);
+    expect(app.message).toHaveBeenCalledWith(
+      /@?handbo(ok|t) (.+)$/i,
+      expect.any(Function)
+    );
+  });
+
+  describe("it handles bot triggers", () => {
+    const message = {
+      context: { matches: [null, null, "search string"] },
+      event: { thread_ts: undefined, ts: 150 },
+      say: jest.fn(),
+    };
+
+    let handler;
+    beforeEach(() => {
+      handbot(app);
+      handler = app.getHandler();
+
+      message.context.matches[2] = "search string";
+    });
+
+    it("gracefully responds if there is an error", async () => {
+      axios.get.mockRejectedValue();
+      await handler(message);
+
+      expect(postEphemeralResponse).toHaveBeenCalledWith(message, {
+        icon_emoji: ":tts:",
+        username: "TTS Handbot",
+        text:
+          "Something went wrong trying to search the Handbook. Please try later!",
+      });
+    });
+
+    it("converts characters accordingly before putting them in the search URL", async () => {
+      message.context.matches[2] = "”some ’search‘ goes here“";
+      await handler(message);
+
+      expect(axios.get).toHaveBeenCalledWith(
+        "https://search.usa.gov/search/?utf8=no&affiliate=tts-handbook&format=json&query=%22some%20'search'%20goes%20here%22"
+      );
+    });
+
+    describe("handles search results coming from search.gov", () => {
+      describe("when the triggering message is not already in a thread", () => {
+        beforeEach(() => {
+          message.event.thread_ts = undefined;
+        });
+
+        it("and there are no search results", async () => {
+          axios.get.mockResolvedValue({ data: { results: [] } });
+          await handler(message);
+
+          expect(message.say).toHaveBeenCalledWith({
+            icon_emoji: ":tts:",
+            username: "TTS Handbot",
+            text: `I couldn't find any results for "search string"`,
+            thread_ts: 150,
+          });
+        });
+
+        it("and there are some results", async () => {
+          axios.get.mockResolvedValue({
+            data: {
+              results: [
+                { body: "this is result #1", link: "link1", title: "result 1" },
+                { body: "this is result #2", link: "link2", title: "result 2" },
+                { body: "this is result #3", link: "link3", title: "result 3" },
+                { body: "this is result #4", link: "link4", title: "result 4" },
+                { body: "this is result #5", link: "link5", title: "result 5" },
+              ],
+            },
+          });
+          await handler(message);
+
+          expect(message.say).toHaveBeenCalledWith({
+            icon_emoji: ":tts:",
+            username: "TTS Handbot",
+            thread_ts: 150,
+            blocks: [
+              {
+                type: "header",
+                text: {
+                  type: "plain_text",
+                  text: 'Handbook search results for "search string"',
+                },
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<link1|result 1>\nthis is result #1",
+                },
+              },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: "link1" }],
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<link2|result 2>\nthis is result #2",
+                },
+              },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: "link2" }],
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<link3|result 3>\nthis is result #3",
+                },
+              },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: "link3" }],
+              },
+            ],
+          });
+        });
+      });
+
+      describe("when the triggering message is in a thread", () => {
+        beforeEach(() => {
+          message.event.thread_ts = 300;
+        });
+
+        it("and there are no search results", async () => {
+          axios.get.mockResolvedValue({ data: { results: [] } });
+          await handler(message);
+
+          expect(message.say).toHaveBeenCalledWith({
+            icon_emoji: ":tts:",
+            username: "TTS Handbot",
+            text: `I couldn't find any results for "search string"`,
+            thread_ts: 300,
+          });
+        });
+
+        it("and there are some results", async () => {
+          axios.get.mockResolvedValue({
+            data: {
+              results: [
+                { body: "this is result #1", link: "link1", title: "result 1" },
+                { body: "this is result #2", link: "link2", title: "result 2" },
+                { body: "this is result #3", link: "link3", title: "result 3" },
+                { body: "this is result #4", link: "link4", title: "result 4" },
+                { body: "this is result #5", link: "link5", title: "result 5" },
+              ],
+            },
+          });
+          await handler(message);
+
+          expect(message.say).toHaveBeenCalledWith({
+            icon_emoji: ":tts:",
+            username: "TTS Handbot",
+            thread_ts: 300,
+            blocks: [
+              {
+                type: "header",
+                text: {
+                  type: "plain_text",
+                  text: 'Handbook search results for "search string"',
+                },
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<link1|result 1>\nthis is result #1",
+                },
+              },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: "link1" }],
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<link2|result 2>\nthis is result #2",
+                },
+              },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: "link2" }],
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<link3|result 3>\nthis is result #3",
+                },
+              },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: "link3" }],
+              },
+            ],
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Triggered by any of these:

```
handbook <search terms>
@handbook <search terms>
handbot <search terms>
@handbot <search terms>
```

Looks like the screenshot in the #284, but with the TTS logo for an icon and "TTS Handbot" as a name. Puts its response into a thread so it doesn't clutter up the channel. Displays the response publicly instead of an "only you can see this message" because the request might actually be useful to multiple people at once.

- closes #284