### PR TITLE
Invalid time conversion fix

### DIFF
--- a/src/scripts/timezone.js
+++ b/src/scripts/timezone.js
@@ -93,6 +93,11 @@ module.exports = (app) => {
         .map(({ id, tz }) => ({ id, tz }));
     });
 
+    // if the detected time is invalid, nothing should be sent to users
+    if (!m.isValid()) {
+      return;
+    }
+
     users.forEach(({ id, tz }) => {
       postEphemeralMessage({
         channel,

--- a/src/scripts/timezone.test.js
+++ b/src/scripts/timezone.test.js
@@ -235,5 +235,12 @@ describe("Handy Tau-bot timezone conversions", () => {
       expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
     });
 
+    it("does not respond to an invalid time", async () => {
+      message.event.text = "25:12";
+      await handler(message);
+
+      expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
+    });
+
   });
 });

--- a/src/scripts/timezone.test.js
+++ b/src/scripts/timezone.test.js
@@ -60,10 +60,14 @@ describe("Handy Tau-bot timezone conversions", () => {
     });
 
     slack.getSlackUsersInConversation.mockResolvedValue([
-      { id: "user 1", tz: "America/Denver" },
-      { id: "user 2", tz: "America/New_York" },
-      { id: "user 3", tz: "America/Chicago" },
-      { id: "user 4", tz: "America/Anchorage" },
+      // puerto rico does not observe daylight savings time and is therefore
+      // excluded from the date-unaware tests to avoid failing half of the year
+      { id: "user ny", tz: "America/New_York" },
+      { id: "user ch", tz: "America/Chicago" },
+      { id: "user dn", tz: "America/Denver" },
+      { id: "user la", tz: "America/Los_Angeles" },
+      { id: "user ak", tz: "America/Anchorage" },
+      // current user
       { id: "user id", tz: "America/Chicago" },
       { id: "bot", is_bot: true },
       { id: "deleted", deleted: true },
@@ -91,15 +95,15 @@ describe("Handy Tau-bot timezone conversions", () => {
       await handler(message);
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 1", "1:00")
+        responseFor("user dn", "1:00")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 3", "2:00")
+        responseFor("user ch", "2:00")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 4", "11:00")
+        responseFor("user ak", "11:00")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
@@ -107,7 +111,7 @@ describe("Handy Tau-bot timezone conversions", () => {
       );
 
       // Make sure only the above messages were posted.
-      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(4);
+      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(5);
     });
 
     it("if a timezone is specified via emoji, it doesn't message people who are in the specified timezone", async () => {
@@ -115,10 +119,10 @@ describe("Handy Tau-bot timezone conversions", () => {
       await handler(message);
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 1", "1:00")
+        responseFor("user dn", "1:00")
       );
-      // trusting the last test to verify contents for the other 3 users
-      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(4);
+      // trusting other tests to verify contents for the other 3 users
+      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(5);
     });
 
     it("if multiple timezones are specified, it only messages people in a different timezone", async () => {
@@ -127,14 +131,14 @@ describe("Handy Tau-bot timezone conversions", () => {
       await handler(message);
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 1", "1:00")
+        responseFor("user dn", "1:00")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 4", "11:00")
+        responseFor("user ak", "11:00")
       );
 
-      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(2);
+      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(3);
     });
 
     it("if a timezone is not specified, it messages everyone except the original author", async () => {
@@ -142,23 +146,27 @@ describe("Handy Tau-bot timezone conversions", () => {
       await handler(message);
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 1", "2:00")
+        responseFor("user ny", "4:00")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 2", "4:00")
+        responseFor("user ch", "3:00")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 3", "3:00")
+        responseFor("user dn", "2:00")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 4", "12:00")
+        responseFor("user la", "1:00")
+      );
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user ak", "12:00")
       );
 
       // Make sure only the above messages were posted.
-      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(4);
+      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(5);
     });
 
     it("includes AM/PM in the message if it was included in the original", async () => {
@@ -166,7 +174,7 @@ describe("Handy Tau-bot timezone conversions", () => {
       await handler(message);
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 1", "2:00 pm")
+        responseFor("user dn", "2:00 pm")
       );
 
       // Not testing filtering here, so trust the previous tests.
@@ -177,15 +185,15 @@ describe("Handy Tau-bot timezone conversions", () => {
       await handler(message);
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 1", "11:15 am")
+        responseFor("user ny", "1:15 pm")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 2", "1:15 pm")
+        responseFor("user dn", "11:15 am")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 4", "9:15 am")
+        responseFor("user ak", "9:15 am")
       );
     });
 
@@ -194,34 +202,30 @@ describe("Handy Tau-bot timezone conversions", () => {
       await handler(message);
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 1", "11:15 pm")
+        responseFor("user ny", "1:15 am")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 2", "1:15 am")
-      );
-
-      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 4", "9:15 pm")
+        responseFor("user la", "10:15 pm")
       );
     });
 
     it("does not message users who have opted-out", async () => {
-      isOptedOut.mockImplementation((userId) => userId === "user 1");
+      isOptedOut.mockImplementation((userId) => userId === "user dn");
 
       message.event.text = "3:00";
       await handler(message);
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 2", "4:00")
+        responseFor("user ny", "4:00")
       );
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 3", "3:00")
+        responseFor("user ch", "3:00")
       );
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user 4", "12:00")
+        responseFor("user ak", "12:00")
       );
-      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(3);
+      expect(slack.postEphemeralMessage.mock.calls.length).toEqual(4);
     });
 
     it("does not respond at all if the user text is empty (e.g., crossposted messages", async () => {
@@ -230,5 +234,6 @@ describe("Handy Tau-bot timezone conversions", () => {
 
       expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
     });
+
   });
 });

--- a/src/scripts/timezone.test.js
+++ b/src/scripts/timezone.test.js
@@ -172,6 +172,40 @@ describe("Handy Tau-bot timezone conversions", () => {
       // Not testing filtering here, so trust the previous tests.
     });
 
+    it("correctly includes AM/PM when crossing noon", async () => {
+      message.event.text = "12:15 pm";
+      await handler(message);
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user 1", "11:15 am")
+      );
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user 2", "1:15 pm")
+      );
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user 4", "9:15 am")
+      );
+    });
+
+    it("correctly includes AM/PM when crossing midnight", async () => {
+      message.event.text = "12:15 am";
+      await handler(message);
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user 1", "11:15 pm")
+      );
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user 2", "1:15 am")
+      );
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user 4", "9:15 pm")
+      );
+    });
+
     it("does not message users who have opted-out", async () => {
       isOptedOut.mockImplementation((userId) => userId === "user 1");
 

--- a/src/scripts/timezone.test.js
+++ b/src/scripts/timezone.test.js
@@ -242,5 +242,19 @@ describe("Handy Tau-bot timezone conversions", () => {
       expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
     });
 
+    // currently failing but may be worth investigating in future
+    it.skip("correctly converts 24 hour time", async () => {
+      message.event.text = "23:42 cst";
+      await handler(message);
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user ny", "12:42 est")
+      );
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user la", "9:42 pst")
+      );
+    });
+
   });
 });

--- a/src/scripts/timezone.test.js
+++ b/src/scripts/timezone.test.js
@@ -242,18 +242,22 @@ describe("Handy Tau-bot timezone conversions", () => {
       expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
     });
 
-    // currently failing but may be worth investigating in future
-    it.skip("correctly converts 24 hour time", async () => {
-      message.event.text = "23:42 cst";
+    it("correctly converts 24 hour time", async () => {
+      message.event.text = "23:42 mst";
       await handler(message);
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user ny", "12:42 est")
+        responseFor("user ny", "1:42")
       );
 
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
-        responseFor("user la", "9:42 pst")
+        responseFor("user ch", "12:42")
       );
+
+      expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
+        responseFor("user la", "10:42")
+      );
+
     });
 
   });


### PR DESCRIPTION
When detected time is considered invalid, will not return an "invalid" message to the user

Alters tests with user region / city abbreviations to be more intuitive when reading tests.
Adds passing tests for invalid time, and time ranges around midnight
Adds a skipped test for 24 hour time which accompanies #292 

Closes https://github.com/18F/charlie/issues/257