### PR TITLE
Update the inclusion bot so it ignores "bipolar disorder"

### DIFF
--- a/src/scripts/inclusion-bot.yaml
+++ b/src/scripts/inclusion-bot.yaml
@@ -98,6 +98,7 @@ triggers:
       - maniac
     ignore:
       - manic monday
+      - bipolar disorder
     alternatives:
       - difficult
       - unpredictable

--- a/src/scripts/inclusion-bot.yaml
+++ b/src/scripts/inclusion-bot.yaml
@@ -76,6 +76,7 @@ triggers:
       - nuts
     ignore:
       - grape nuts
+      - nuts and bolts
     alternatives:
       - hard to believe
       - bananas


### PR DESCRIPTION
We want to trigger on slang uses of "bipolar," but when someone is talking about bipolar disorder, the bot shouldn't chime in. (See [the Slack comment](https://gsa-tts.slack.com/archives/C02DJFR0V/p1622222665164700) that inspired this PR.)