### PR TITLE
For Inclusion Bot, ignore utterances that are in quotes

### DIFF
--- a/src/scripts/inclusion-bot.js
+++ b/src/scripts/inclusion-bot.js
@@ -21,6 +21,10 @@ const getTriggers = () => {
     triggers: triggers.map(({ ignore, matches, ...rest }) => ({
       ignore: ignore && RegExp(`(${ignore.join("|")})`, "ig"),
       matches: RegExp(
+        // The backend of this regex (starting at "(?=") is using a positive
+        // lookahead to un-match things that are inside quotes (regular double
+        // quotes, single quote, or smart quotes). You can play around with the
+        // regex here: https://regexr.com/61eiq
         `(${matches.join("|")})(?=[^"“”']*(["“”'][^"“”']*["“”'][^"“”']*)*$)`,
         "i"
       ),

--- a/src/scripts/inclusion-bot.js
+++ b/src/scripts/inclusion-bot.js
@@ -20,7 +20,10 @@ const getTriggers = () => {
     message,
     triggers: triggers.map(({ ignore, matches, ...rest }) => ({
       ignore: ignore && RegExp(`(${ignore.join("|")})`, "ig"),
-      matches: RegExp(`(${matches.join("|")})`, "i"),
+      matches: RegExp(
+        `(${matches.join("|")})(?=[^"“”']*(["“”'][^"“”']*["“”'][^"“”']*)*$)`,
+        "i"
+      ),
       ...rest,
     })),
   };


### PR DESCRIPTION
This will allow people to have conversations about words without being spammed by the bot. For example, this text will not trigger the bot:

```
Let's talk about "ninja" movies
```