### PR TITLE
Switch from Moment.js to the Temporal API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,9 @@
     "es6": true,
     "node": true
   },
+  "globals": {
+    "Temporal": "readonly"
+  },
   "parserOptions": { "ecmaVersion": 2020 },
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5046,19 +5046,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-    },
-    "moment-timezone": {
-      "version": "0.5.33",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1033,6 +1033,74 @@
         "chalk": "^4.0.0"
       }
     },
+    "@js-temporal/polyfill": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.2.0.tgz",
+      "integrity": "sha512-GyjuWEUpK2i+hGIfFOEdA8iVS4xPNLupwCgU9CiQFbMH+QW8De/4egT1MSod3ZmPDLyuxvFJ1285Cg3QuZOVBQ==",
+      "requires": {
+        "big-integer": "^1.6.48",
+        "es-abstract": "^1.18.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
+          "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.3",
+            "is-string": "^1.0.6",
+            "object-inspect": "^1.11.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          }
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+        },
+        "unbox-primitive": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+          "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has-bigints": "^1.0.1",
+            "has-symbols": "^1.0.2",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -1753,6 +1821,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -3634,6 +3707,16 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -6369,6 +6452,16 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@18f/us-federal-holidays": "^2.0.1",
+    "@js-temporal/polyfill": "^0.2.0",
     "@slack/bolt": "^3.5.0",
     "aws-sdk": "^2.963.0",
     "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "sinon": "^11.1.2"
   },
   "jest": {
+    "setupFiles": ["./src/polyfill.js"],
     "testEnvironment": "node"
   },
   "prettier": {}

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "cfenv": "^1.2.3",
     "dotenv": "^10.0.0",
     "js-yaml": "^4.1.0",
-    "moment": "^2.27.0",
-    "moment-timezone": "^0.5.32",
     "node-schedule": "^2.0.0",
     "pg": "^8.7.1"
   },
@@ -36,7 +34,9 @@
     "sinon": "^11.1.2"
   },
   "jest": {
-    "setupFiles": ["./src/polyfill.js"],
+    "setupFiles": [
+      "./src/polyfill.js"
+    ],
     "testEnvironment": "node"
   },
   "prettier": {}

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+require("./polyfill");
+
 require("./env");
 const { App, LogLevel } = require("@slack/bolt");
 const fs = require("fs").promises;

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,0 +1,7 @@
+const { Intl, Temporal, toTemporalInstant } = require("@js-temporal/polyfill");
+
+global.Intl.DateTimeFormat = Intl.DateTimeFormat;
+global.Temporal = Temporal;
+
+// eslint-disable-next-line no-extend-native
+Date.prototype.toTemporalInstant = toTemporalInstant;

--- a/src/scripts/angry-tock.js
+++ b/src/scripts/angry-tock.js
@@ -1,7 +1,7 @@
-const { Temporal } = require("@js-temporal/polyfill");
 const holidays = require("@18f/us-federal-holidays");
 const scheduler = require("node-schedule");
 const {
+  dates: { DAYS },
   slack: { postMessage, sendDirectMessage },
   tock: { get18FTockSlackUsers, get18FTockTruants },
 } = require("../utils");
@@ -112,12 +112,15 @@ const shout = async ({ calm = false } = {}) => {
 
 /**
  * Gets whether or not a given date/time is a Angry Tock shouting day.
- * @param {Moment} now The date/time to check, as a Moment object
+ * @param {Temporal.ZonedDateTime} now The date/time to check, as a Temporal.ZonedDateTime object
  * @returns {Boolean} True if the passed date/time is a good day for shouting
  */
 const isAngryTockDay = (now) => {
   const d = now || m();
-  return d.dayOfWeek === 1 && !holidays.isAHoliday(dateFromZonedDateTime(m()));
+  return (
+    d.dayOfWeek === DAYS.Monday &&
+    !holidays.isAHoliday(dateFromZonedDateTime(m()))
+  );
 };
 
 /**
@@ -134,7 +137,6 @@ const scheduleNextShoutingMatch = () => {
   if (isAngryTockDay(day)) {
     // If today is the normal day for Angry Tock to shout...
     if (Temporal.ZonedDateTime.compare(day, firstTockShoutTime) < 0) {
-      // day.isBefore(firstTockShoutTime)) {
       // ...and Angry Tock should not have shouted at all yet, schedule a calm
       // shout.
       return scheduler.scheduleJob(

--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -1,4 +1,3 @@
-const moment = require("moment-timezone");
 const sinon = require("sinon");
 const scheduler = require("node-schedule");
 
@@ -125,37 +124,34 @@ describe("Angry Tock", () => {
     it("if it is shouty day and before first-shout time, schedules a first-shout", async () => {
       // Monday, April 8, 1974: Hank Aaron hits his 715th career homerun,
       // breaking Babe Ruth's record.
-      const time = moment.tz(
-        "1974-04-08 00:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
+      const time = Temporal.ZonedDateTime.from(
+        `1974-04-08T00:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
-      clock.tick(time.toDate().getTime());
+      clock.tick(time.toInstant().epochMilliseconds);
 
       const angryTock = await load();
       angryTock(app);
 
-      time.hour(10);
       expect(scheduleJob).toHaveBeenCalledWith(
-        time.toDate(),
+        new Date(time.with({ hour: 10 }).toInstant().epochMilliseconds),
         expect.any(Function)
       );
     });
 
     it("if it is shouty day, after the first-shout time but before the second-shout time, schedules a second-shout", async () => {
       // Monday, May 20, 1991: Michael Jordan named NBA MVP.
-      const time = moment.tz(
-        "1991-05-20 11:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
+      const time = Temporal.ZonedDateTime.from(
+        `1991-05-20 11:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
-      clock.tick(time.toDate().getTime());
+      clock.tick(time.toInstant().epochMilliseconds);
 
       const angryTock = await load();
       angryTock(app);
 
-      time.hour(14);
-      time.minute(45);
       expect(scheduleJob).toHaveBeenCalledWith(
-        time.toDate(),
+        new Date(
+          time.with({ hour: 14, minute: 45 }).toInstant().epochMilliseconds
+        ),
         expect.any(Function)
       );
     });
@@ -165,23 +161,21 @@ describe("Angry Tock", () => {
       // as President of the United States.
       // Angry Tock is not location aware, but inauguration day is a holiday for
       // DC-area federal employees. So... just a note for the future!
-      const initial = moment.tz(
-        "1997-01-27 20:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
+      const initial = Temporal.ZonedDateTime.from(
+        `1997-01-27 20:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
-      clock.tick(initial.toDate().getTime());
+      clock.tick(initial.toInstant().epochMilliseconds);
 
       const angryTock = await load();
       angryTock(app);
 
       // Monday, February 3, 1997 - Cornell University faculty, staff, and
       // students gathered for a public memorial for Carl Sagan.
-      const scheduled = moment.tz(
-        "1997-02-03 10:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
+      const scheduled = Temporal.ZonedDateTime.from(
+        `1997-02-03 10:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
       expect(scheduleJob).toHaveBeenCalledWith(
-        scheduled.toDate(),
+        new Date(scheduled.toInstant().epochMilliseconds),
         expect.any(Function)
       );
     });
@@ -190,23 +184,21 @@ describe("Angry Tock", () => {
       // Friday, October 18, 2019 - First all-female spacewalk conducted by NASA
       // astronauts Christina Koch and Jessica Meir outside of the Internaional
       // Space Station.
-      const initial = moment.tz(
-        "2019-10-18 09:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
+      const initial = Temporal.ZonedDateTime.from(
+        `2019-10-18 09:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
-      clock.tick(initial.toDate().getTime());
+      clock.tick(initial.toInstant().epochMilliseconds);
 
       const angryTock = await load();
       angryTock(app);
 
       // Monday, October 21, 2019 - World's oldest natural pearl, dated at 8,000
       // years old, is found new Abu Dhabi.
-      const scheduled = moment.tz(
-        "2019-10-21 10:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
+      const scheduled = Temporal.ZonedDateTime.from(
+        `2019-10-21 10:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
       expect(scheduleJob).toHaveBeenCalledWith(
-        scheduled.toDate(),
+        new Date(scheduled.toInstant().epochMilliseconds),
         expect.any(Function)
       );
     });
@@ -215,11 +207,10 @@ describe("Angry Tock", () => {
   it("sends a calm/disappointed message first, then an angry message and truant report", async () => {
     // Monday, May 1, 1978 - Ernest Nathan Morial, first African-American mayor
     // of New Orleans, is inaugurated.
-    const initial = moment.tz(
-      "1978-05-01 09:00:00",
-      process.env.ANGRY_TOCK_TIMEZONE
+    const initial = Temporal.ZonedDateTime.from(
+      `1978-05-01 09:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
     );
-    clock.tick(initial.toDate().getTime());
+    clock.tick(initial.toInstant().epochMilliseconds);
 
     const angryTock = await load();
     angryTock(app);
@@ -228,7 +219,7 @@ describe("Angry Tock", () => {
     // scheduler and run it, but first advance the time so that the "angry"
     // shout gets scheduled next. We need to advance time up to the initial
     // "shout" time so that future shouts are scheduled correctly.
-    await clock.tickAsync(moment.duration({ hours: 2 }).asMilliseconds());
+    await clock.tickAsync(2 * 60 * 60 * 1000);
     const calmShout = scheduleJob.mock.calls[0][1];
     await calmShout();
 

--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -217,7 +217,9 @@ describe("Angry Tock", () => {
     // scheduler and run it, but first advance the time so that the "angry"
     // shout gets scheduled next. We need to advance time up to the initial
     // "shout" time so that future shouts are scheduled correctly.
-    await clock.tickAsync(2 * 60 * 60 * 1000);
+    await clock.tickAsync(
+      Temporal.Duration.from({ hours: 2 }).total({ unit: "millisecond" })
+    );
     const calmShout = scheduleJob.mock.calls[0][1];
     await calmShout();
 

--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -281,8 +281,7 @@ describe("Angry Tock", () => {
           fallback:
             "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
           color: "#FF0000",
-          text:
-            "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
+          text: "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
         },
       ],
       username: "Angry Tock",

--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -127,13 +127,13 @@ describe("Angry Tock", () => {
       const time = Temporal.ZonedDateTime.from(
         `1974-04-08T00:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
-      clock.tick(time.toInstant().epochMilliseconds);
+      clock.tick(time.epochMilliseconds);
 
       const angryTock = await load();
       angryTock(app);
 
       expect(scheduleJob).toHaveBeenCalledWith(
-        new Date(time.with({ hour: 10 }).toInstant().epochMilliseconds),
+        new Date(time.with({ hour: 10 }).epochMilliseconds),
         expect.any(Function)
       );
     });
@@ -143,15 +143,13 @@ describe("Angry Tock", () => {
       const time = Temporal.ZonedDateTime.from(
         `1991-05-20 11:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
-      clock.tick(time.toInstant().epochMilliseconds);
+      clock.tick(time.epochMilliseconds);
 
       const angryTock = await load();
       angryTock(app);
 
       expect(scheduleJob).toHaveBeenCalledWith(
-        new Date(
-          time.with({ hour: 14, minute: 45 }).toInstant().epochMilliseconds
-        ),
+        new Date(time.with({ hour: 14, minute: 45 }).epochMilliseconds),
         expect.any(Function)
       );
     });
@@ -164,7 +162,7 @@ describe("Angry Tock", () => {
       const initial = Temporal.ZonedDateTime.from(
         `1997-01-27 20:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
-      clock.tick(initial.toInstant().epochMilliseconds);
+      clock.tick(initial.epochMilliseconds);
 
       const angryTock = await load();
       angryTock(app);
@@ -175,7 +173,7 @@ describe("Angry Tock", () => {
         `1997-02-03 10:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
       expect(scheduleJob).toHaveBeenCalledWith(
-        new Date(scheduled.toInstant().epochMilliseconds),
+        new Date(scheduled.epochMilliseconds),
         expect.any(Function)
       );
     });
@@ -187,7 +185,7 @@ describe("Angry Tock", () => {
       const initial = Temporal.ZonedDateTime.from(
         `2019-10-18 09:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
-      clock.tick(initial.toInstant().epochMilliseconds);
+      clock.tick(initial.epochMilliseconds);
 
       const angryTock = await load();
       angryTock(app);
@@ -198,7 +196,7 @@ describe("Angry Tock", () => {
         `2019-10-21 10:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
       );
       expect(scheduleJob).toHaveBeenCalledWith(
-        new Date(scheduled.toInstant().epochMilliseconds),
+        new Date(scheduled.epochMilliseconds),
         expect.any(Function)
       );
     });
@@ -210,7 +208,7 @@ describe("Angry Tock", () => {
     const initial = Temporal.ZonedDateTime.from(
       `1978-05-01 09:00:00[${process.env.ANGRY_TOCK_TIMEZONE}]`
     );
-    clock.tick(initial.toInstant().epochMilliseconds);
+    clock.tick(initial.epochMilliseconds);
 
     const angryTock = await load();
     angryTock(app);

--- a/src/scripts/encourage-bot.js
+++ b/src/scripts/encourage-bot.js
@@ -6,11 +6,12 @@
 // in the #random channel.
 
 const holidays = require("@18f/us-federal-holidays");
-const moment = require("moment-timezone");
 const scheduler = require("node-schedule");
 const {
+  dates: { getNow },
   slack: { getChannelID, getSlackUsersInConversation, postMessage },
 } = require("../utils");
+const { DAYS, zonedDateTimeToDate } = require("../utils/dates");
 
 const CHANNEL = "random";
 
@@ -45,7 +46,7 @@ const tellSomeoneTheyAreAwesome = async (channel) => {
   // Trim down the list of users to just those whose current time is between
   // 9am and 5pm locally.
   const workingHourUsers = users.filter(({ tz }) => {
-    const userCurrentHour = moment.tz(tz).hour();
+    const userCurrentHour = getNow(tz).hour;
     return userCurrentHour > 9 && userCurrentHour < 17;
   });
 
@@ -69,72 +70,66 @@ const tzCompare = "2000-01-01T00:00:00.000";
 const scheduleAnotherReminder = async (app, channel) => {
   const users = await getChannelUsers(channel);
   const timezones = Array.from(new Set(users.map(({ tz }) => tz))).sort(
-    (a, b) => {
-      const aa = moment.tz(tzCompare, a);
-      const bb = moment.tz(tzCompare, b);
-
-      if (aa.isBefore(bb)) {
-        return -1;
-      }
-      if (bb.isBefore(aa)) {
-        return 1;
-      }
-      return 0;
-    }
+    (a, b) =>
+      Temporal.ZonedDateTime.compare(
+        Temporal.ZonedDateTime.from(`${tzCompare}[${a}]`),
+        Temporal.ZonedDateTime.from(`${tzCompare}[${b}]`)
+      )
   );
 
   const earliest = timezones[0];
   const latest = timezones.pop();
 
-  const next = moment.tz(earliest);
-  const tzSpan = moment
-    .tz(tzCompare, latest)
-    .diff(moment.tz(tzCompare, earliest), "hours");
+  const { hours: tzSpan } = Temporal.ZonedDateTime.from(
+    `${tzCompare}[${earliest}]`
+  ).until(
+    Temporal.ZonedDateTime.from(`${tzCompare}[${latest}]`, {
+      largestUnit: "hour",
+      smallestUnit: "hour",
+    })
+  );
 
   // Tell someone else. Wait at least 2 hours, but not more than 48 hours, and
   // just totally randomize the minutes because that's fun.
-  const hoursFromNow = Math.floor(Math.random() * 48 + 2);
-  const minutesFromNow = Math.floor(Math.random() * 60);
-
-  next.add(hoursFromNow, "hours");
-  next.add(minutesFromNow, "minutes");
+  let next = getNow(earliest).add({
+    hours: Math.floor(Math.random() * 48 + 2),
+    minutes: Math.floor(Math.random() * 60),
+  });
 
   // If the new time is outside of everyone's working hours, advance forward
   // until we get inside working hours. Randomize the hours so we're not always
   // doing an announcement in the 9 o'clock hour on the east coast. Randomize
   // by the number of hours between the earliest and latest timezones, so there
   // is a chance of including everyone.
-  while (next.hour() < 9 || moment.tz(next, latest).hour() >= 17) {
-    next.add(Math.floor(Math.random() * tzSpan), "hour");
+  while (next.hour < 9 || next.withTimeZone(latest).hour >= 17) {
+    next = next.add({ hours: Math.floor(Math.random() * tzSpan) });
   }
   // Make sure we didn't land on a holiday. If we did, hop forward one day at a
   // time until we're out of the holiday. Strictly speaking, we could just hop
   // forward once since we don't have any consecutive holidays, but this script
   // is optimistic for a future where consecutive holidays are possible.
-  while (holidays.isAHoliday(next.toDate())) {
-    next.add(1, "day");
+  while (holidays.isAHoliday(zonedDateTimeToDate(next))) {
+    next = next.add({ days: 1 });
   }
   // The new time could also have been on the weekend, or we could have been
   // advanced to the weekend by a Friday holiday, so make sure we bustle out of
   // those, too.
-  while (next.day() === 0 || next.day() === 6) {
-    next.add(1, "day");
+  while (next.dayOfWeek === DAYS.Sunday || next.dayOfWeek === DAYS.Saturday) {
+    next = next.add({ days: 1 });
   }
   // Check for holidays again. If, for example, we initially landed on a
   // Saturday and there's a Monday holiday, we need to catch that.
-  while (holidays.isAHoliday(next.toDate())) {
-    next.add(1, "day");
+  while (holidays.isAHoliday(zonedDateTimeToDate(next))) {
+    next = next.add({ days: 1 });
   }
 
   app.logger.info(
-    `[Encourage Bot] Next encouragement is ${next.format(
-      "dddd, MMMM Do YYYY, h:mm:ss a zz"
-    )}`
+    `[Encourage Bot] Next encouragement is ${next.toLocaleString()}`
   );
 
   // Schedule the next announcement, which includes scheduling the one after
   // that. The train never ends! 🚂
-  scheduler.scheduleJob(next.toDate(), async () =>
+  scheduler.scheduleJob(zonedDateTimeToDate(next), async () =>
     Promise.all([
       tellSomeoneTheyAreAwesome(channel),
       scheduleAnotherReminder(app, channel),

--- a/src/scripts/encourage-bot.test.js
+++ b/src/scripts/encourage-bot.test.js
@@ -49,7 +49,7 @@ describe("Encouragement bot", () => {
       // run, ideally in isolation.
     ].forEach(({ desc, when }) => {
       it(desc, async () => {
-        jest.setSystemTime(when.toInstant().epochMilliseconds);
+        jest.setSystemTime(when.epochMilliseconds);
 
         await bot(app);
         expect(scheduleJob).toHaveBeenCalled();
@@ -72,7 +72,7 @@ describe("Encouragement bot", () => {
         expect(early.dayOfWeek).not.toBe(6);
         expect(early.hour).toBeGreaterThanOrEqual(9);
         expect(late.hour).toBeLessThan(17);
-        expect(isAHoliday(new Date(early.toInstant().epochMilliseconds))).toBe(
+        expect(isAHoliday(new Date(early.epochMilliseconds))).toBe(
           false
         );
       });

--- a/src/scripts/federal-holidays-reminder.js
+++ b/src/scripts/federal-holidays-reminder.js
@@ -1,26 +1,35 @@
-const moment = require("moment-timezone");
 const scheduler = require("node-schedule");
 const {
-  dates: { getNextHoliday },
+  dates: { getNextHoliday, zonedDateTimeToDate, DAYS },
   holidays: { emojis },
   slack: { postMessage },
 } = require("../utils");
 
 const CHANNEL = process.env.HOLIDAY_REMINDER_CHANNEL || "general";
 const TIMEZONE = process.env.HOLIDAY_REMINDER_TIMEZONE || "America/New_York";
-const reportingTime = moment(
-  process.env.HOLIDAY_REMINDER_TIME || "15:00",
-  "HH:mm"
+const reportingTime = Temporal.PlainTime.from(
+  process.env.HOLIDAY_REMINDER_TIME || "15:00"
 );
 
-const previousWeekday = (date) => {
-  const source = moment(date);
-  source.subtract(1, "day");
+const dows = [
+  undefined,
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
 
-  let dow = source.format("dddd");
-  while (dow === "Saturday" || dow === "Sunday") {
-    source.subtract(1, "day");
-    dow = source.format("dddd");
+const previousWeekday = (date) => {
+  let source = date.subtract({ days: 1 });
+
+  while (
+    source.dayOfWeek === DAYS.Saturday ||
+    source.dayOfWeek === DAYS.Sunday
+  ) {
+    source = source.subtract({ days: 1 });
   }
 
   return source;
@@ -31,26 +40,32 @@ const postReminder = (holiday) => {
 
   postMessage({
     channel: CHANNEL,
-    text: `@here Remember that *${holiday.date.format(
-      "dddd"
-    )}* is a federal holiday in observance of *${holiday.name}*${
+    text: `@here Remember that *${
+      dows[holiday.date.dayOfWeek]
+    }* is a federal holiday in observance of *${holiday.name}*${
       emoji ? ` ${emoji}` : ""
     }!`,
   });
 };
 
 const scheduleReminder = () => {
-  const nextHoliday = module.exports.getNextHoliday(TIMEZONE);
+  const nextHoliday = getNextHoliday(TIMEZONE);
   const target = module.exports.previousWeekday(nextHoliday.date);
 
-  target.hour(reportingTime.hour());
-  target.minute(reportingTime.minute());
+  const when = Temporal.ZonedDateTime.from({
+    year: target.year,
+    month: target.month,
+    day: target.day,
+    hour: reportingTime.hour,
+    minute: reportingTime.minute,
+    timeZone: TIMEZONE,
+  });
 
-  scheduler.scheduleJob(target.toDate(), () => {
+  scheduler.scheduleJob(zonedDateTimeToDate(when), () => {
     module.exports.postReminder(nextHoliday);
 
     // Tomorrow, schedule the next holiday reminder
-    scheduler.scheduleJob(target.add(1, "day").toDate(), () => {
+    scheduler.scheduleJob(zonedDateTimeToDate(when.add({ days: 1 })), () => {
       scheduleReminder();
     });
   });
@@ -59,6 +74,5 @@ const scheduleReminder = () => {
 module.exports = scheduleReminder;
 
 // Expose for testing
-module.exports.getNextHoliday = getNextHoliday;
 module.exports.postReminder = postReminder;
 module.exports.previousWeekday = previousWeekday;

--- a/src/scripts/federal-holidays-reminder.test.js
+++ b/src/scripts/federal-holidays-reminder.test.js
@@ -131,11 +131,9 @@ describe("holiday reminder", () => {
 
       expect(scheduleJob).toHaveBeenCalledWith(
         new Date(
-          Date.parse(
-            Temporal.ZonedDateTime.from(
-              "2000-01-01T15:00:00[America/New_York]"
-            ).toInstant()
-          )
+          Temporal.ZonedDateTime.from(
+            "2000-01-01T15:00:00[America/New_York]"
+          ).epochMilliseconds
         ),
         expect.any(Function)
       );
@@ -151,11 +149,9 @@ describe("holiday reminder", () => {
       // of January first like the previous expect.
       expect(scheduleJob).toHaveBeenCalledWith(
         new Date(
-          Date.parse(
-            Temporal.ZonedDateTime.from(
-              "2000-01-02T15:00:00[America/New_York]"
-            ).toInstant()
-          )
+          Temporal.ZonedDateTime.from(
+            "2000-01-02T15:00:00[America/New_York]"
+          ).epochMilliseconds
         ),
         expect.any(Function)
       );
@@ -181,11 +177,9 @@ describe("holiday reminder", () => {
 
       expect(scheduleJob).toHaveBeenCalledWith(
         new Date(
-          Date.parse(
-            Temporal.ZonedDateTime.from(
-              "2000-01-01T04:32:00[America/New_York]"
-            ).toInstant()
-          )
+          Temporal.ZonedDateTime.from(
+            "2000-01-01T04:32:00[America/New_York]"
+          ).epochMilliseconds
         ),
         expect.any(Function)
       );
@@ -200,11 +194,9 @@ describe("holiday reminder", () => {
 
       expect(scheduleJob).toHaveBeenCalledWith(
         new Date(
-          Date.parse(
-            Temporal.ZonedDateTime.from(
-              "2000-01-02T04:32:00[America/New_York]"
-            ).toInstant()
-          )
+          Temporal.ZonedDateTime.from(
+            "2000-01-02T04:32:00[America/New_York]"
+          ).epochMilliseconds
         ),
         expect.any(Function)
       );

--- a/src/scripts/federal-holidays.js
+++ b/src/scripts/federal-holidays.js
@@ -1,9 +1,27 @@
 const { directMention } = require("@slack/bolt");
-const moment = require("moment");
 const {
-  dates: { getNextHoliday },
+  dates: { getNextHoliday, getToday },
   holidays: { emojis },
 } = require("../utils");
+
+// The PluralRules API is not implemented in the polyfill, so revert to the
+// global instance.
+const pr = new Intl.PluralRules("en-US", { type: "ordinal" });
+const suffixes = new Map([
+  ["one", "st"],
+  ["two", "nd"],
+  ["few", "rd"],
+  ["other", "th"],
+]);
+const getOrdinal = (n) => {
+  const rule = pr.select(n);
+  return suffixes.get(rule);
+};
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+});
 
 module.exports = (app) => {
   app.message(
@@ -11,17 +29,18 @@ module.exports = (app) => {
     /(when is( the)? )?next (federal )?holiday/i,
     ({ say }) => {
       const holiday = getNextHoliday();
-      const nextOne = moment(holiday.date);
-      const daysUntil = Math.ceil(
-        moment.duration(nextOne.utc().format("x") - Date.now()).asDays()
-      );
+      const today = getToday();
+
+      const { days: daysUntil } = today.until(holiday.date);
 
       const emoji = emojis.get(holiday.name);
 
       say(
         `The next federal holiday is ${holiday.name} ${emoji || ""}${
           emoji ? " " : ""
-        }in ${daysUntil} days on ${nextOne.utc().format("dddd, MMMM Do")}`
+        }in ${daysUntil} days on ${dateFormatter.format(
+          holiday.date
+        )}${getOrdinal(holiday.date.day)}`
       );
     }
   );

--- a/src/scripts/federal-holidays.js
+++ b/src/scripts/federal-holidays.js
@@ -4,8 +4,6 @@ const {
   holidays: { emojis },
 } = require("../utils");
 
-// The PluralRules API is not implemented in the polyfill, so revert to the
-// global instance.
 const pr = new Intl.PluralRules("en-US", { type: "ordinal" });
 const suffixes = new Map([
   ["one", "st"],
@@ -31,7 +29,7 @@ module.exports = (app) => {
       const holiday = getNextHoliday();
       const today = getToday();
 
-      const { days: daysUntil } = today.until(holiday.date);
+      const daysUntil = today.until(holiday.date).total({ unit: "day" });
 
       const emoji = emojis.get(holiday.name);
 

--- a/src/scripts/federal-holidays.test.js
+++ b/src/scripts/federal-holidays.test.js
@@ -26,7 +26,12 @@ describe("federal holidays bot", () => {
 
   it("responds to a request for the next federal holiday", () => {
     const clock = sinon.useFakeTimers();
-    clock.tick(1000 * 60 * 60 * 12);
+    // This gets us past midnight on January 1, 1970 in half the world, which is
+    // necessary for internal code that uses Date objects, since they can't
+    // handle times before then.
+    clock.tick(
+      Temporal.Duration.from({ hours: 12 }).total({ unit: "millisecond" })
+    );
     bot(app);
     const handler = app.getHandler();
     const say = jest.fn();
@@ -47,7 +52,9 @@ describe("federal holidays bot", () => {
 
   it("includes an emoji for well-known holidays", () => {
     const clock = sinon.useFakeTimers();
-    clock.tick(1000 * 60 * 60 * 12);
+    clock.tick(
+      Temporal.Duration.from({ hours: 12 }).total({ unit: "millisecond" })
+    );
     bot(app);
     const handler = app.getHandler();
     const say = jest.fn();

--- a/src/scripts/federal-holidays.test.js
+++ b/src/scripts/federal-holidays.test.js
@@ -1,4 +1,3 @@
-const moment = require("moment-timezone");
 const sinon = require("sinon");
 const { getApp } = require("../utils/test");
 const bot = require("./federal-holidays");
@@ -27,12 +26,13 @@ describe("federal holidays bot", () => {
 
   it("responds to a request for the next federal holiday", () => {
     const clock = sinon.useFakeTimers();
+    clock.tick(1000 * 60 * 60 * 12);
     bot(app);
     const handler = app.getHandler();
     const say = jest.fn();
 
     getNextHoliday.mockReturnValue({
-      date: moment.tz("1970-01-02T00:00:00", "UTC"),
+      date: Temporal.PlainDate.from("1970-01-02"),
       name: "Test Holiday day",
     });
 
@@ -47,12 +47,13 @@ describe("federal holidays bot", () => {
 
   it("includes an emoji for well-known holidays", () => {
     const clock = sinon.useFakeTimers();
+    clock.tick(1000 * 60 * 60 * 12);
     bot(app);
     const handler = app.getHandler();
     const say = jest.fn();
 
     getNextHoliday.mockReturnValue({
-      date: moment.tz("1970-01-02T00:00:00", "UTC"),
+      date: Temporal.PlainDate.from("1970-01-02"),
       name: "Christmas Day",
     });
 

--- a/src/scripts/optimistic-tock.js
+++ b/src/scripts/optimistic-tock.js
@@ -95,8 +95,14 @@ module.exports = async (app) => {
     while (nextSunday.dayOfWeek !== DAYS.Sunday) {
       nextSunday = nextSunday.add({ days: 1 });
     }
-    // "Not after" rather than "before" to handle the edge where these
-    // two are identical. So... Sundays. Also the tests.
+    // If today is Sunday, then the loop above wouldn't have done anything, so
+    // advance forward a week. This check is primarily only necessary at bot
+    // start up: it first schedules the most immediate reminder and then calls
+    // this function to schedule the following reminder. If the bot starts on a
+    // Sunday, then the scheduleJob below would be run immediately, meaning the
+    // most immediate reminders would run twice. So, if the bot starts on a
+    // Sunday, punt the next schedulefest for a week. There's probably a much
+    // cleaner way to address this.
     if (Temporal.ZonedDateTime.compare(nextSunday, getNow()) <= 0) {
       nextSunday = nextSunday.add({ days: 7 });
     }

--- a/src/scripts/optimistic-tock.test.js
+++ b/src/scripts/optimistic-tock.test.js
@@ -220,7 +220,9 @@ describe("Optimistic Tock", () => {
       // Before we call the re-scheduler, reset the mock to clear out the set of
       // scheduled jobs from start-up.. Also fast-forward in time by a week.
       scheduleJob.mockClear();
-      clock.tick(7 * 24 * 60 * 60 * 1000);
+      clock.tick(
+        Temporal.Duration.from({ days: 7 }).total({ unit: "millisecond" })
+      );
 
       // Now let's see what happens!
       await rescheduler();

--- a/src/scripts/optimistic-tock.test.js
+++ b/src/scripts/optimistic-tock.test.js
@@ -134,7 +134,7 @@ describe("Optimistic Tock", () => {
   });
 
   const dateFrom = (str) =>
-    new Date(Temporal.ZonedDateTime.from(str).toInstant().epochMilliseconds);
+    new Date(Temporal.ZonedDateTime.from(str).epochMilliseconds);
 
   describe("it schedules future reminders", () => {
     it("for the next Friday if it is not a holiday", async () => {

--- a/src/scripts/optimistic-tock.test.js
+++ b/src/scripts/optimistic-tock.test.js
@@ -1,4 +1,3 @@
-const moment = require("moment-timezone");
 const sinon = require("sinon");
 const scheduler = require("node-schedule");
 
@@ -134,16 +133,18 @@ describe("Optimistic Tock", () => {
     });
   });
 
+  const dateFrom = (str) =>
+    new Date(Temporal.ZonedDateTime.from(str).toInstant().epochMilliseconds);
+
   describe("it schedules future reminders", () => {
     it("for the next Friday if it is not a holiday", async () => {
       // The Bell System is broken up by antitrust action.
-      const time = moment.tz("1984-01-01T12:32:18", "America/New_York");
-      clock.tick(time.toDate().getTime());
+      clock.tick(dateFrom("1984-01-01T12:32:18[America/New_York]").getTime());
 
       const times = [
-        moment.tz("1984-01-06T16:00:00", "America/New_York").toDate(),
-        moment.tz("1984-01-06T16:00:00", "America/Chicago").toDate(),
-        moment.tz("1984-01-06T16:00:00", "America/Los_Angeles").toDate(),
+        dateFrom("1984-01-06T16:00:00[America/New_York]"),
+        dateFrom("1984-01-06T16:00:00[America/Chicago]"),
+        dateFrom("1984-01-06T16:00:00[America/Los_Angeles]"),
       ];
 
       const optimisticTock = await load();
@@ -165,7 +166,7 @@ describe("Optimistic Tock", () => {
       // The following week's reminders should be for the next Sunday, at the
       // same time of day as when the bot started.
       expect(scheduleJob).toHaveBeenCalledWith(
-        moment.tz("1984-01-08T12:32:18", "America/New_York").toDate(),
+        dateFrom("1984-01-08T12:32:18[America/New_York]"),
         expect.any(Function)
       );
     });
@@ -173,13 +174,12 @@ describe("Optimistic Tock", () => {
     it("for the next Thursday if Friday is a holiday", async () => {
       // I don't know if this is a significant date, but July 4 was a Friday
       // in 1986, so it meets our test criteria.
-      const time = moment.tz("1986-07-01T12:43:44", "America/New_York");
-      clock.tick(time.toDate().getTime());
+      clock.tick(dateFrom("1986-07-01T12:43:44[America/New_York]").getTime());
 
       const times = [
-        moment.tz("1986-07-03T16:00:00", "America/New_York").toDate(),
-        moment.tz("1986-07-03T16:00:00", "America/Chicago").toDate(),
-        moment.tz("1986-07-03T16:00:00", "America/Los_Angeles").toDate(),
+        dateFrom("1986-07-03T16:00:00[America/New_York]"),
+        dateFrom("1986-07-03T16:00:00[America/Chicago]"),
+        dateFrom("1986-07-03T16:00:00[America/Los_Angeles]"),
       ];
 
       const optimisticTock = await load();
@@ -201,7 +201,7 @@ describe("Optimistic Tock", () => {
       // The following week's reminders should be for the next Sunday, at the
       // same time of day as when the bot started.
       expect(scheduleJob).toHaveBeenCalledWith(
-        moment.tz("1986-07-06T12:43:44", "America/New_York").toDate(),
+        dateFrom("1986-07-06T12:43:44[America/New_York]"),
         expect.any(Function)
       );
     });
@@ -209,8 +209,7 @@ describe("Optimistic Tock", () => {
     it("schedules more reminders for following weeks", async () => {
       // The wreck of the Titanic is found. A Monday. We all feel a little like
       // wrecks on Mondays, don't we?
-      const time = moment.tz("1985-09-02T09:45:00", "America/New_York");
-      clock.tick(time.toDate().getTime());
+      clock.tick(dateFrom("1985-09-02T09:45:00[America/New_York]").getTime());
 
       const optimisticTock = await load();
       await optimisticTock(app);
@@ -221,7 +220,7 @@ describe("Optimistic Tock", () => {
       // Before we call the re-scheduler, reset the mock to clear out the set of
       // scheduled jobs from start-up.. Also fast-forward in time by a week.
       scheduleJob.mockClear();
-      clock.tick(moment.duration(7, "days").asMilliseconds());
+      clock.tick(7 * 24 * 60 * 60 * 1000);
 
       // Now let's see what happens!
       await rescheduler();
@@ -233,9 +232,9 @@ describe("Optimistic Tock", () => {
       expect(scheduleJob.mock.calls.length).toBe(4);
 
       [
-        moment.tz("1985-09-13T16:00:00", "America/New_York").toDate(),
-        moment.tz("1985-09-13T16:00:00", "America/Chicago").toDate(),
-        moment.tz("1985-09-13T16:00:00", "America/Los_Angeles").toDate(),
+        dateFrom("1985-09-13T16:00:00[America/New_York]"),
+        dateFrom("1985-09-13T16:00:00[America/Chicago]"),
+        dateFrom("1985-09-13T16:00:00[America/Los_Angeles]"),
       ].forEach((scheduledTime) => {
         expect(scheduleJob).toHaveBeenCalledWith(
           scheduledTime,
@@ -246,7 +245,7 @@ describe("Optimistic Tock", () => {
       // The following week's reminders should be for the next Sunday, at the
       // same time of day as when the bot started.
       expect(scheduleJob).toHaveBeenCalledWith(
-        moment.tz("1985-09-15T09:45:00", "America/New_York").toDate(),
+        dateFrom("1985-09-15T09:45:00[America/New_York]"),
         expect.any(Function)
       );
     });
@@ -257,8 +256,7 @@ describe("Optimistic Tock", () => {
 
     beforeAll(async () => {
       // The Bell System is broken up by antitrust action.
-      const time = moment.tz("1984-01-01T12:00:00", "America/New_York");
-      clock.tick(time.toDate().getTime());
+      clock.tick(dateFrom("1984-01-01T12:00:00[America/New_York]").getTime());
 
       const optimisticTock = await load();
       await optimisticTock(app);

--- a/src/scripts/timezone.js
+++ b/src/scripts/timezone.js
@@ -1,5 +1,3 @@
-const { Temporal } = require("@js-temporal/polyfill");
-
 const {
   optOut,
   slack: { getSlackUsersInConversation, postEphemeralMessage },

--- a/src/scripts/timezone.js
+++ b/src/scripts/timezone.js
@@ -28,23 +28,14 @@ const TIMEZONES = {
   pst: "America/Los_Angeles",
 };
 
+const timeFormatter = new Intl.DateTimeFormat("en", {
+  hour: "numeric",
+  minute: "numeric",
+});
+
 const timeString = (zonedDateTime, ampm) => {
-  const { hour: h, minute } = Temporal.PlainTime.from(zonedDateTime);
-
-  let ampmStr = "";
-  if (ampm) {
-    if (h < 12) {
-      ampmStr = " am";
-    } else {
-      ampmStr = " pm";
-    }
-  }
-
-  const hour = h === 0 ? 12 : h;
-
-  return `${hour > 12 ? hour - 12 : hour}:${
-    minute > 10 ? "" : "0"
-  }${minute}${ampmStr}`;
+  const str = timeFormatter.format(zonedDateTime.toPlainTime()).toLowerCase();
+  return ampm ? str : str.replace(/(a|p)m/gi, "").trim();
 };
 
 const matcher =

--- a/src/scripts/timezone.js
+++ b/src/scripts/timezone.js
@@ -52,7 +52,7 @@ module.exports = (app) => {
     } = await msg.client.users.info({ user });
 
     let users = await getSlackUsersInConversation(msg);
-    let m = null;
+    let timeToTranslate = null;
     let ampm = null;
 
     const matches = [...text.matchAll(RegExp(matcher, "gi"))];
@@ -69,7 +69,7 @@ module.exports = (app) => {
         ? TIMEZONES[timezone.toLowerCase()]
         : authorTimezone;
 
-      if (m === null) {
+      if (timeToTranslate === null) {
         ampm = ampmStr;
 
         let hour = +h;
@@ -85,7 +85,7 @@ module.exports = (app) => {
           return;
         }
 
-        m = Temporal.Now.instant()
+        timeToTranslate = Temporal.Now.instant()
           .toZonedDateTime({ calendar: "iso8601", timeZone: sourceTz })
           .withPlainTime({ hour, minute });
       }
@@ -116,7 +116,7 @@ module.exports = (app) => {
     });
 
     // if the detected time is invalid, nothing should be sent to users
-    if (!m) {
+    if (!timeToTranslate) {
       return;
     }
 
@@ -127,7 +127,7 @@ module.exports = (app) => {
         user: id,
         username: "Handy Tau-bot",
         text: `That's ${timeString(
-          m.withTimeZone({ timeZone: tz }),
+          timeToTranslate.withTimeZone({ timeZone: tz }),
           ampm
         )} for you!`,
         thread_ts: thread,
@@ -137,7 +137,7 @@ module.exports = (app) => {
             text: {
               type: "mrkdwn",
               text: `That's ${timeString(
-                m.withTimeZone({ timeZone: tz }),
+                timeToTranslate.withTimeZone({ timeZone: tz }),
                 ampm
               )} for you!`,
             },

--- a/src/scripts/timezone.test.js
+++ b/src/scripts/timezone.test.js
@@ -78,7 +78,7 @@ describe("Handy Tau-bot timezone conversions", () => {
     timezone(app);
 
     expect(app.message).toHaveBeenCalledWith(
-      /(\d{1,2}:\d{2}\s?(am|pm)?)\s?(((ak|a|c|e|m|p)(s|d)?t)|:(eastern|central|mountain|pacific)-time-zone:)?/i,
+      /(\d{1,2}):(\d{2})\s?(am|pm)?\s?(((ak|a|c|e|m|p)(s|d)?t)|:(eastern|central|mountain|pacific)-time-zone:)?/i,
       expect.any(Function)
     );
   });
@@ -257,8 +257,6 @@ describe("Handy Tau-bot timezone conversions", () => {
       expect(slack.postEphemeralMessage).toHaveBeenCalledWith(
         responseFor("user la", "10:42")
       );
-
     });
-
   });
 });

--- a/src/scripts/travel-team.js
+++ b/src/scripts/travel-team.js
@@ -1,6 +1,6 @@
 const holidays = require("@18f/us-federal-holidays");
 const {
-  dates: { getNow, DAYS },
+  dates: { getNow, zonedDateTimeToDate, DAYS },
 } = require("../utils");
 
 // Saturday and Sunday; day numbers are according to the Temporal spec. Weekday
@@ -32,15 +32,15 @@ const getChannelName = (() => {
 })();
 
 const travelIsClosed = (day = getNow()) =>
-  holidays.isAHoliday(new Date(Date.parse(day.toInstant()))) ||
+  holidays.isAHoliday(zonedDateTimeToDate(day)) ||
   closedDays.includes(day.dayOfWeek);
 
 const getNextWorkday = () => {
-  let m = getNow().add({ days: 1 });
-  while (travelIsClosed(m)) {
-    m = m.add({ days: 1 });
+  let nextWorkDay = getNow().add({ days: 1 });
+  while (travelIsClosed(nextWorkDay)) {
+    nextWorkDay = nextWorkDay.add({ days: 1 });
   }
-  return dows[m.dayOfWeek];
+  return dows[nextWorkDay.dayOfWeek];
 };
 
 const pastResponses = [];

--- a/src/scripts/travel-team.js
+++ b/src/scripts/travel-team.js
@@ -1,7 +1,21 @@
 const holidays = require("@18f/us-federal-holidays");
-const moment = require("moment");
+const {
+  dates: { getNow, DAYS },
+} = require("../utils");
 
-const closedDays = ["Saturday", "Sunday"];
+// Saturday and Sunday; day numbers are according to the Temporal spec. Weekday
+// indexes now start at 1, and 0 is undefined.
+const closedDays = [DAYS.Saturday, DAYS.Sunday];
+const dows = [
+  undefined,
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
 
 const getChannelName = (() => {
   let allChannels = null;
@@ -17,15 +31,16 @@ const getChannelName = (() => {
   };
 })();
 
-const travelIsClosed = (day = moment()) =>
-  holidays.isAHoliday(day.toDate()) || closedDays.includes(day.format("dddd"));
+const travelIsClosed = (day = getNow()) =>
+  holidays.isAHoliday(new Date(Date.parse(day.toInstant()))) ||
+  closedDays.includes(day.dayOfWeek);
 
 const getNextWorkday = () => {
-  const m = moment().add(1, "day");
+  let m = getNow().add({ days: 1 });
   while (travelIsClosed(m)) {
-    m.add(1, "day");
+    m = m.add({ days: 1 });
   }
-  return m.format("dddd");
+  return dows[m.dayOfWeek];
 };
 
 const pastResponses = [];

--- a/src/scripts/travel-team.test.js
+++ b/src/scripts/travel-team.test.js
@@ -72,8 +72,7 @@ describe("Travel team weekend/holiday notice", () => {
 
         expect(message.say).toHaveBeenCalledWith({
           icon_emoji: ":tts:",
-          text:
-            "Hi <@user id>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Friday morning and someone will respond promptly.",
+          text: "Hi <@user id>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Friday morning and someone will respond promptly.",
           thread_ts: "thread id",
           username: "TTS Travel Team",
         });
@@ -89,8 +88,7 @@ describe("Travel team weekend/holiday notice", () => {
 
         expect(message.say).toHaveBeenCalledWith({
           icon_emoji: ":tts:",
-          text:
-            "Hi <@user id>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.",
+          text: "Hi <@user id>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.",
           thread_ts: "thread id",
           username: "TTS Travel Team",
         });
@@ -105,8 +103,7 @@ describe("Travel team weekend/holiday notice", () => {
 
         expect(message.say).toHaveBeenCalledWith({
           icon_emoji: ":tts:",
-          text:
-            "Hi <@user id>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.",
+          text: "Hi <@user id>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.",
           thread_ts: "thread id",
           username: "TTS Travel Team",
         });
@@ -121,8 +118,7 @@ describe("Travel team weekend/holiday notice", () => {
 
         expect(message.say).toHaveBeenCalledWith({
           icon_emoji: ":tts:",
-          text:
-            "Hi <@user id>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.",
+          text: "Hi <@user id>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.",
           thread_ts: "thread id",
           username: "TTS Travel Team",
         });
@@ -144,7 +140,9 @@ describe("Travel team weekend/holiday notice", () => {
         message.say.mockClear();
 
         // Now move forwar 3 hours and see that we get a new message for the user
-        clock.tick(3 * 60 * 60 * 1000);
+        clock.tick(
+          Temporal.Duration.from({ hours: 3 }).total({ unit: "milliseconds" })
+        );
         await handler(message);
 
         expect(message.say).toHaveBeenCalled();

--- a/src/scripts/what-day-is-it.js
+++ b/src/scripts/what-day-is-it.js
@@ -4,17 +4,43 @@
    with what we've got.
 */
 
+const { Temporal, toTemporalInstant, Intl } = require("@js-temporal/polyfill");
 const { directMention } = require("@slack/bolt");
-const moment = require("moment-timezone");
 
-const endOfMarch = moment.tz("2021-01-19T23:59:59Z", "America/New_York");
+// This will be able to go away when the polyfill is replaced with a native
+// implementation, probably sometime in 2022. The polyfill is not for production
+// use anyway, so all of this is just playing, getting ready.
+// eslint-disable-next-line no-extend-native
+Date.prototype.toTemporalInstant = toTemporalInstant;
+
+const lastOfMarch2020 = Temporal.PlainDate.from({
+  year: 2021,
+  month: 1,
+  day: 19,
+});
+
+const fmt = new Intl.DateTimeFormat("en-US", {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+});
 
 module.exports = (app) => {
   app.message(directMention(), /what day is it/i, ({ say }) => {
-    const now = moment.tz("America/New_York");
-    const date = now.format("dddd, MMMM Do, YYYY");
-    const days = Math.ceil(moment.duration(now.diff(endOfMarch)).as("days"));
+    const today = Temporal.PlainDate.from(
+      Temporal.Now.instant().toZonedDateTime({
+        calendar: "iso8601",
+        timeZone: "America/New_York",
+      })
+    );
 
-    say(`Today is ${date}. It has been ${days} days since March 2020.`);
+    const { days } = today.since(lastOfMarch2020);
+
+    say(
+      `Today is ${fmt.format(
+        today
+      )}. It has been ${days} days since March 2020.`
+    );
   });
 };

--- a/src/scripts/what-day-is-it.js
+++ b/src/scripts/what-day-is-it.js
@@ -4,14 +4,8 @@
    with what we've got.
 */
 
-const { Temporal, toTemporalInstant, Intl } = require("@js-temporal/polyfill");
+const { Temporal, Intl } = require("@js-temporal/polyfill");
 const { directMention } = require("@slack/bolt");
-
-// This will be able to go away when the polyfill is replaced with a native
-// implementation, probably sometime in 2022. The polyfill is not for production
-// use anyway, so all of this is just playing, getting ready.
-// eslint-disable-next-line no-extend-native
-Date.prototype.toTemporalInstant = toTemporalInstant;
 
 const lastOfMarch2020 = Temporal.PlainDate.from({
   year: 2021,

--- a/src/scripts/what-day-is-it.js
+++ b/src/scripts/what-day-is-it.js
@@ -4,7 +4,6 @@
    with what we've got.
 */
 
-const { Temporal, Intl } = require("@js-temporal/polyfill");
 const { directMention } = require("@slack/bolt");
 
 const lastOfMarch2020 = Temporal.PlainDate.from({

--- a/src/scripts/what-day-is-it.test.js
+++ b/src/scripts/what-day-is-it.test.js
@@ -33,7 +33,7 @@ describe("the jokey March 2020 date thingy", () => {
     handler({ say });
 
     expect(say).toHaveBeenCalledWith(
-      "Today is Saturday, January 23rd, 2021. It has been 4 days since March 2020."
+      "Today is Saturday, January 23, 2021. It has been 4 days since March 2020."
     );
   });
 });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,4 +1,6 @@
-const CACHE_MAX_LIFE = 20 * 60 * 1000;
+const CACHE_MAX_LIFE = Temporal.Duration.from({ minutes: 20 }).total({
+  unit: "milliseconds",
+});
 
 const cache = (() => {
   const privateCache = new Map();

--- a/src/utils/cache.test.js
+++ b/src/utils/cache.test.js
@@ -29,7 +29,9 @@ describe("utils / cache", () => {
   // so that it doesn't expire on the next auto-clean. That is correct
   // behavior, but it's hard to account for. Having this test first moots it.
   it("clears itself of things that are more than 20 minutes old", async () => {
-    const TWENTY_MINUTES = 20 * 60 * 1000;
+    const TWENTY_MINUTES = Temporal.Duration.from({ minutes: 20 }).total({
+      unit: "milliseconds",
+    });
 
     const callback = jest.fn().mockResolvedValue("");
 

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,18 +1,34 @@
-const moment = require("moment-timezone");
+const { Temporal } = require("@js-temporal/polyfill");
 const holidays = require("@18f/us-federal-holidays");
 
-const getNextHoliday = (timezone = "America/New_York") => {
-  const now = moment.tz(timezone);
+const getNextHoliday = (timeZone = "America/New_York") => {
+  const now = Temporal.Now.instant().toZonedDateTime({
+    calendar: "iso8601",
+    timeZone,
+  });
 
-  return holidays
-    .allForYear(now.year())
-    .concat(holidays.allForYear(now.year() + 1))
-    .map((h) => ({
-      ...h,
-      date: moment.tz(h.dateString, "YYYY-MM-DD", timezone),
-    }))
-    .filter((h) => h.date.isAfter(now))
-    .shift();
+  return (
+    holidays
+      .allForYear(now.year)
+      .concat(holidays.allForYear(now.year + 1))
+      .map((h) => {
+        const [year, m, d] = h.dateString.split("-");
+        const month = m < 10 ? `0${m}` : m;
+        const day = d < 10 ? `0${d}` : d;
+
+        return {
+          ...h,
+          date: Temporal.ZonedDateTime.from(
+            `${[year, month, day].join("-")}[${timeZone}]`
+          ),
+        };
+      })
+      .filter(({ date }) => Temporal.ZonedDateTime.compare(date, now) > 0)
+      // Eventually this could just return Temporal.PlainDate objects, but not yet
+      // because downstream code expects this to return legacy Date objects
+      .map((h) => ({ ...h, date: new Date(Date.parse(h.date.toInstant())) }))
+      .shift()
+  );
 };
 
 module.exports = { getNextHoliday };

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -18,32 +18,26 @@ const getNow = (timeZone = "America/New_York") =>
 const getToday = (timeZone = "America/New_York") =>
   getNow(timeZone).toPlainDate();
 
-const zonedDateTimeToDate = (zdt) =>
-  new Date(zdt.toInstant().epochMilliseconds);
+const zonedDateTimeToDate = (zdt) => new Date(zdt.epochMilliseconds);
 
 const getNextHoliday = (timeZone = "America/New_York") => {
   const now = getToday(timeZone);
 
-  return (
-    holidays
-      .allForYear(now.year)
-      .concat(holidays.allForYear(now.year + 1))
-      .map((h) => {
-        const [year, m, d] = h.dateString.split("-");
-        const month = String(m).padStart(2, "0");
-        const day = String(d).padStart(2, "0");
+  return holidays
+    .allForYear(now.year)
+    .concat(holidays.allForYear(now.year + 1))
+    .map((h) => {
+      const [year, m, d] = h.dateString.split("-");
+      const month = String(m).padStart(2, "0");
+      const day = String(d).padStart(2, "0");
 
-        return {
-          ...h,
-          date: Temporal.PlainDate.from(`${[year, month, day].join("-")}`),
-        };
-      })
-      .filter(({ date }) => Temporal.PlainDate.compare(date, now) > 0)
-      // Eventually this could just return Temporal.PlainDate objects, but not yet
-      // because downstream code expects this to return legacy Date objects
-      // .map((h) => ({ ...h, date: new Date(Date.parse(h.date.toInstant())) }))
-      .shift()
-  );
+      return {
+        ...h,
+        date: Temporal.PlainDate.from(`${[year, month, day].join("-")}`),
+      };
+    })
+    .filter(({ date }) => Temporal.PlainDate.compare(date, now) > 0)
+    .shift();
 };
 
 module.exports = {

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,11 +1,28 @@
-const { Temporal } = require("@js-temporal/polyfill");
 const holidays = require("@18f/us-federal-holidays");
 
+const calendar = "iso8601";
+
+const DAYS = {
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+  Sunday: 7,
+};
+
+const getNow = (timeZone = "America/New_York") =>
+  Temporal.Now.instant().toZonedDateTime({ calendar, timeZone });
+
+const getToday = (timeZone = "America/New_York") =>
+  getNow(timeZone).toPlainDate();
+
+const zonedDateTimeToDate = (zdt) =>
+  new Date(zdt.toInstant().epochMilliseconds);
+
 const getNextHoliday = (timeZone = "America/New_York") => {
-  const now = Temporal.Now.instant().toZonedDateTime({
-    calendar: "iso8601",
-    timeZone,
-  });
+  const now = getToday(timeZone);
 
   return (
     holidays
@@ -13,22 +30,26 @@ const getNextHoliday = (timeZone = "America/New_York") => {
       .concat(holidays.allForYear(now.year + 1))
       .map((h) => {
         const [year, m, d] = h.dateString.split("-");
-        const month = m < 10 ? `0${m}` : m;
-        const day = d < 10 ? `0${d}` : d;
+        const month = String(m).padStart(2, "0");
+        const day = String(d).padStart(2, "0");
 
         return {
           ...h,
-          date: Temporal.ZonedDateTime.from(
-            `${[year, month, day].join("-")}[${timeZone}]`
-          ),
+          date: Temporal.PlainDate.from(`${[year, month, day].join("-")}`),
         };
       })
-      .filter(({ date }) => Temporal.ZonedDateTime.compare(date, now) > 0)
+      .filter(({ date }) => Temporal.PlainDate.compare(date, now) > 0)
       // Eventually this could just return Temporal.PlainDate objects, but not yet
       // because downstream code expects this to return legacy Date objects
-      .map((h) => ({ ...h, date: new Date(Date.parse(h.date.toInstant())) }))
+      // .map((h) => ({ ...h, date: new Date(Date.parse(h.date.toInstant())) }))
       .shift()
   );
 };
 
-module.exports = { getNextHoliday };
+module.exports = {
+  getNextHoliday,
+  getNow,
+  getToday,
+  zonedDateTimeToDate,
+  DAYS,
+};

--- a/src/utils/dates.test.js
+++ b/src/utils/dates.test.js
@@ -2,14 +2,12 @@ const sinon = require("sinon");
 const { getNextHoliday } = require("./dates");
 
 const midnight = ({ year, month, day }) =>
-  Date.parse(
-    Temporal.ZonedDateTime.from({
-      year,
-      month,
-      day,
-      timeZone: "America/New_York",
-    }).toInstant()
-  );
+  Temporal.ZonedDateTime.from({
+    year,
+    month,
+    day,
+    timeZone: "America/New_York",
+  }).epochMilliseconds;
 
 describe("gets the next holiday", () => {
   it("defaults to America/New_York time", async () => {

--- a/src/utils/dates.test.js
+++ b/src/utils/dates.test.js
@@ -1,21 +1,27 @@
-const moment = require("moment-timezone");
 const sinon = require("sinon");
 const { getNextHoliday } = require("./dates");
+
+const midnight = ({ year, month, day }) =>
+  Date.parse(
+    Temporal.ZonedDateTime.from({
+      year,
+      month,
+      day,
+      timeZone: "America/New_York",
+    }).toInstant()
+  );
 
 describe("gets the next holiday", () => {
   it("defaults to America/New_York time", async () => {
     // Midnight on May 28 in eastern timezone
     const clock = sinon.useFakeTimers(
-      +moment.tz("2012-05-28", "YYYY-MM-DD", "America/New_York").format("x")
+      midnight({ year: 2012, month: 5, day: 28 })
     );
 
     const nextHoliday = getNextHoliday();
 
-    expect(moment(nextHoliday.date).isValid()).toBe(true);
-
-    // remove this from the object match, otherwise
-    // it becomes a whole big thing, dependent on
-    // moment not changing its internal object structure
+    // remove this from the object match, because jest doesn't currently have
+    // Temporal type matchers
     delete nextHoliday.date;
 
     expect(nextHoliday).toEqual({
@@ -31,16 +37,13 @@ describe("gets the next holiday", () => {
     // timezone is US central timezone, "now" is still May 27, so the
     // "next" holiday should be May 28 - Memorial Day
     const clock = sinon.useFakeTimers(
-      +moment.tz("2012-05-28", "YYYY-MM-DD", "America/New_York").format("x")
+      midnight({ year: 2012, month: 5, day: 28 })
     );
 
     const nextHoliday = getNextHoliday("America/Chicago");
 
-    expect(moment(nextHoliday.date).isValid()).toBe(true);
-
-    // remove this from the object match, otherwise
-    // it becomes a whole big thing, dependent on
-    // moment not changing its internal object structure
+    // remove this from the object match, because jest doesn't currently have
+    // Temporal type matchers
     delete nextHoliday.date;
 
     expect(nextHoliday).toEqual({

--- a/src/utils/optOut.test.js
+++ b/src/utils/optOut.test.js
@@ -1,5 +1,6 @@
 const { brain } = require("./test");
-const optOutModule = require("./optOut");
+
+const optOutModule = jest.requireActual("./optOut");
 
 describe("opt-out utility", () => {
   let optOut;

--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -4,8 +4,19 @@ const { cache, dates, optOut, slack, tock } = require("./index");
 
 // Mock axios and the utility functions, to make it easier for tests to use.
 jest.mock("axios");
+
+// Mock our stuff individually. Some of these don't need to be mocked, like
+// the ones that just operate on or generate constants (specifically the date
+// utilities).
 jest.mock("../brain");
-jest.mock("./index");
+jest.mock("./cache");
+jest.mock("./dates", () => ({
+  ...jest.requireActual("./dates"),
+  getNextHoliday: jest.fn(),
+}));
+jest.mock("./optOut");
+jest.mock("./slack");
+jest.mock("./tock");
 
 module.exports = {
   getApp: () => {

--- a/src/utils/tock.js
+++ b/src/utils/tock.js
@@ -1,7 +1,7 @@
-const { Temporal } = require("@js-temporal/polyfill");
 const axios = require("axios");
 const { cache } = require("./cache");
 const { getSlackUsers } = require("./slack");
+const { DAYS } = require("./dates");
 
 const tockAPI = axios.create({
   baseURL: process.env.TOCK_API,
@@ -60,7 +60,7 @@ const getCurrent18FTockUsers = async () => {
  */
 const get18FTockTruants = async (now, weeksAgo = 1) => {
   let reportStart = now;
-  while (reportStart.dayOfWeek !== 7) {
+  while (reportStart.dayOfWeek !== DAYS.Sunday) {
     reportStart = reportStart.subtract({ days: 1 });
   }
   // We're now at the nearest past Sunday, but that's the start of the

--- a/src/utils/tock.test.js
+++ b/src/utils/tock.test.js
@@ -1,6 +1,5 @@
 const axios = require("axios");
 const sinon = require("sinon");
-const { Temporal } = require("@js-temporal/polyfill");
 const slack = require("./slack");
 
 describe("utils / tock", () => {

--- a/src/utils/tock.test.js
+++ b/src/utils/tock.test.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
-const moment = require("moment");
 const sinon = require("sinon");
+const { Temporal } = require("@js-temporal/polyfill");
 const slack = require("./slack");
 
 describe("utils / tock", () => {
@@ -202,8 +202,14 @@ describe("utils / tock", () => {
     });
 
     it("defaults to looking at the reporting period from a week ago", async () => {
-      const date = moment("2020-10-14");
-      clock.tick(date.toDate().getTime());
+      const date = Temporal.PlainDate.from("2020-10-14");
+      clock.tick(
+        Date.parse(
+          date
+            .toZonedDateTime({ timeZone: Temporal.Now.timeZone() })
+            .toInstant()
+        )
+      );
       const truants = await get18FTockTruants(date);
 
       // Only user 1 is truant from the previous period.
@@ -213,8 +219,14 @@ describe("utils / tock", () => {
     });
 
     it("defaults to looking at the reporting period from this week", async () => {
-      const date = moment("2020-10-14");
-      clock.tick(date.toDate().getTime());
+      const date = Temporal.PlainDate.from("2020-10-14");
+      clock.tick(
+        Date.parse(
+          date
+            .toZonedDateTime({ timeZone: Temporal.Now.timeZone() })
+            .toInstant()
+        )
+      );
       const truants = await get18FTockTruants(date, 0);
 
       // Only user 5 is truant in the current period.

--- a/src/utils/tock.test.js
+++ b/src/utils/tock.test.js
@@ -203,11 +203,8 @@ describe("utils / tock", () => {
     it("defaults to looking at the reporting period from a week ago", async () => {
       const date = Temporal.PlainDate.from("2020-10-14");
       clock.tick(
-        Date.parse(
-          date
-            .toZonedDateTime({ timeZone: Temporal.Now.timeZone() })
-            .toInstant()
-        )
+        date.toZonedDateTime({ timeZone: Temporal.Now.timeZone() })
+          .epochMilliseconds
       );
       const truants = await get18FTockTruants(date);
 
@@ -220,11 +217,8 @@ describe("utils / tock", () => {
     it("defaults to looking at the reporting period from this week", async () => {
       const date = Temporal.PlainDate.from("2020-10-14");
       clock.tick(
-        Date.parse(
-          date
-            .toZonedDateTime({ timeZone: Temporal.Now.timeZone() })
-            .toInstant()
-        )
+        date.toZonedDateTime({ timeZone: Temporal.Now.timeZone() })
+          .epochMilliseconds
       );
       const truants = await get18FTockTruants(date, 0);
 


### PR DESCRIPTION
# Longterm WIP

The [Temporal API](https://tc39.es/proposal-temporal/docs/index.html) is currently a TC39 stage 3 proposal, which means the API is nearly completed and is not expected to change much more before final approval. It will be a while yet before it has native implementations, but there's no reason we can't start playing with it now using the polyfill.

The goal of this WIP PR is to explore migrating every current use of Moment.js in Charlie to the Temporal API. Some of those may be harder than others, and may justify switching to a different library instead of using the Temporal API directly. Since there's no rush to make this change, a long-running PR seemed like a reasonable approach to figuring out what we should do.

The following parts of the bot rely on Moment.js and should be migrated:

- [x] angry Tock
- [x] encourage bot
- [x] federal holidays reminder
- [x] federal holidays
- [x] optimistic Tock
- [x] timezone ("Tau bot")
- [x] travel team bot
- [x] what-day-is-it (March 2020 bot)
- [x] utils/dates

This PR is a step towards addressing #295.