### PR TITLE
Poor encouragement bot, hardly ever gets to run

### DIFF
--- a/src/scripts/encourage-bot.js
+++ b/src/scripts/encourage-bot.js
@@ -12,6 +12,7 @@ const {
   slack: { getChannelID, getSlackUsersInConversation, postMessage },
 } = require("../utils");
 
+const BRAIN_KEY = "encourage-bot-schedule";
 const CHANNEL = "random";
 
 const messages = [
@@ -66,64 +67,81 @@ const tellSomeoneTheyAreAwesome = async (channel) => {
 };
 
 const tzCompare = "2000-01-01T00:00:00.000";
-const scheduleAnotherReminder = async (app, channel) => {
-  const users = await getChannelUsers(channel);
-  const timezones = Array.from(new Set(users.map(({ tz }) => tz))).sort(
-    (a, b) => {
-      const aa = moment.tz(tzCompare, a);
-      const bb = moment.tz(tzCompare, b);
+const scheduleAnotherReminder = async (app, channel, time) => {
+  // The incoming time is an ISO8601 string, so we can safely load that as the
+  // US eastern timezone.
+  let next = moment.tz(time, "America/New_York");
 
-      if (aa.isBefore(bb)) {
-        return -1;
+  // If there is *NOT* an incoming time OR if it is in the past, then we  need
+  // to pick a new time. If there is an incoming time in the future, we will
+  // trust that it is valid according to the rules below rather than checking
+  // them all again.
+  //
+  // Use "not after" because we also want to exclude the case where the stored
+  // time is exactly now. The reason is that if we schedule a future event for
+  // now, it may never fire (it becomes a race condition), in which case it will
+  // also never schedule subsequent events and the bot just won't ever do
+  // anything. So... if the saved time is now, just do a new one.
+  if (!time || !next.isAfter(moment())) {
+    const users = await getChannelUsers(channel);
+    const timezones = Array.from(new Set(users.map(({ tz }) => tz))).sort(
+      (a, b) => {
+        const aa = moment.tz(tzCompare, a);
+        const bb = moment.tz(tzCompare, b);
+
+        if (aa.isBefore(bb)) {
+          return -1;
+        }
+        if (bb.isBefore(aa)) {
+          return 1;
+        }
+        return 0;
       }
-      if (bb.isBefore(aa)) {
-        return 1;
-      }
-      return 0;
+    );
+
+    const earliest = timezones[0];
+    const latest = timezones.pop();
+
+    next = moment.tz(earliest);
+    const tzSpan = moment
+      .tz(tzCompare, latest)
+      .diff(moment.tz(tzCompare, earliest), "hours");
+
+    // Tell someone else. Wait at least 2 hours, but not more than 48 hours, and
+    // just totally randomize the minutes because that's fun.
+    const hoursFromNow = Math.floor(Math.random() * 48 + 2);
+    const minutesFromNow = Math.floor(Math.random() * 60);
+
+    next.add(hoursFromNow, "hours");
+    next.add(minutesFromNow, "minutes");
+
+    // If the new time is outside of everyone's working hours, advance forward
+    // until we get inside working hours. Randomize the hours so we're not always
+    // doing an announcement in the 9 o'clock hour on the east coast. Randomize
+    // by the number of hours between the earliest and latest timezones, so there
+    // is a chance of including everyone.
+    while (next.hour() < 9 || moment.tz(next, latest).hour() >= 17) {
+      const hours = Math.floor(Math.random() * tzSpan);
+      next.add(hours > 0 ? hours : 1, "hours");
     }
-  );
-
-  const earliest = timezones[0];
-  const latest = timezones.pop();
-
-  const next = moment.tz(earliest);
-  const tzSpan = moment
-    .tz(tzCompare, latest)
-    .diff(moment.tz(tzCompare, earliest), "hours");
-
-  // Tell someone else. Wait at least 2 hours, but not more than 48 hours, and
-  // just totally randomize the minutes because that's fun.
-  const hoursFromNow = Math.floor(Math.random() * 48 + 2);
-  const minutesFromNow = Math.floor(Math.random() * 60);
-
-  next.add(hoursFromNow, "hours");
-  next.add(minutesFromNow, "minutes");
-
-  // If the new time is outside of everyone's working hours, advance forward
-  // until we get inside working hours. Randomize the hours so we're not always
-  // doing an announcement in the 9 o'clock hour on the east coast. Randomize
-  // by the number of hours between the earliest and latest timezones, so there
-  // is a chance of including everyone.
-  while (next.hour() < 9 || moment.tz(next, latest).hour() >= 17) {
-    next.add(Math.floor(Math.random() * tzSpan), "hour");
-  }
-  // Make sure we didn't land on a holiday. If we did, hop forward one day at a
-  // time until we're out of the holiday. Strictly speaking, we could just hop
-  // forward once since we don't have any consecutive holidays, but this script
-  // is optimistic for a future where consecutive holidays are possible.
-  while (holidays.isAHoliday(next.toDate())) {
-    next.add(1, "day");
-  }
-  // The new time could also have been on the weekend, or we could have been
-  // advanced to the weekend by a Friday holiday, so make sure we bustle out of
-  // those, too.
-  while (next.day() === 0 || next.day() === 6) {
-    next.add(1, "day");
-  }
-  // Check for holidays again. If, for example, we initially landed on a
-  // Saturday and there's a Monday holiday, we need to catch that.
-  while (holidays.isAHoliday(next.toDate())) {
-    next.add(1, "day");
+    // Make sure we didn't land on a holiday. If we did, hop forward one day at a
+    // time until we're out of the holiday. Strictly speaking, we could just hop
+    // forward once since we don't have any consecutive holidays, but this script
+    // is optimistic for a future where consecutive holidays are possible.
+    while (holidays.isAHoliday(next.toDate())) {
+      next.add(1, "day");
+    }
+    // The new time could also have been on the weekend, or we could have been
+    // advanced to the weekend by a Friday holiday, so make sure we bustle out of
+    // those, too.
+    while (next.day() === 0 || next.day() === 6) {
+      next.add(1, "day");
+    }
+    // Check for holidays again. If, for example, we initially landed on a
+    // Saturday and there's a Monday holiday, we need to catch that.
+    while (holidays.isAHoliday(next.toDate())) {
+      next.add(1, "day");
+    }
   }
 
   app.logger.info(
@@ -131,6 +149,9 @@ const scheduleAnotherReminder = async (app, channel) => {
       "dddd, MMMM Do YYYY, h:mm:ss a zz"
     )}`
   );
+
+  // Save the scheduled time so we can pick it up again when the bot restarts.
+  app.brain.set(BRAIN_KEY, next.toISOString());
 
   // Schedule the next announcement, which includes scheduling the one after
   // that. The train never ends! 🚂
@@ -143,6 +164,8 @@ const scheduleAnotherReminder = async (app, channel) => {
 };
 
 module.exports = async (app) => {
+  const time = app.brain.get(BRAIN_KEY);
+
   const channel = await getChannelID(CHANNEL);
-  await scheduleAnotherReminder(app, channel);
+  await scheduleAnotherReminder(app, channel, time);
 };


### PR DESCRIPTION
This bot schedules future cheers between 2 and 48 hours in the future! That's great! But it's statistically most likely to schedule for the next day, always, and that's not really a problem except that the bot is automatically restaged every night with the practical upshot that the bot basically just never runs because it's perpetually rescheduled for tomorrow.

The fix: let the bot stash the scheduled time in its brain and use that at startup.