### PR TITLE
Refactor tests

### DIFF
--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -122,68 +122,72 @@ describe("Angry Tock", () => {
   });
 
   describe("schedules the next shouting match on startup", () => {
-    it("if it is shouty day and before first-shout time, schedules a first-shout", async () => {
-      // Monday, April 8, 1974: Hank Aaron hits his 715th career homerun,
-      // breaking Babe Ruth's record.
-      const time = moment.tz(
-        "1974-04-08 00:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
-      );
-      clock.tick(time.toDate().getTime());
+    describe("if it is a shouty day", () => {
+      it("before first-shout time, schedules a first-shout", async () => {
+        // Monday, April 8, 1974: Hank Aaron hits his 715th career homerun,
+        // breaking Babe Ruth's record.
+        const time = moment.tz(
+          "1974-04-08 00:00:00",
+          process.env.ANGRY_TOCK_TIMEZONE
+        );
+        clock.tick(time.toDate().getTime());
 
-      const angryTock = await load();
-      angryTock(app);
+        const angryTock = await load();
+        angryTock(app);
 
-      time.hour(10);
-      expect(scheduleJob).toHaveBeenCalledWith(
-        time.toDate(),
-        expect.any(Function)
-      );
-    });
+        time.hour(10);
+        expect(scheduleJob).toHaveBeenCalledWith(
+          time.toDate(),
+          expect.any(Function)
+        );
+      });
 
-    it("if it is shouty day, after the first-shout time but before the second-shout time, schedules a second-shout", async () => {
-      // Monday, May 20, 1991: Michael Jordan named NBA MVP.
-      const time = moment.tz(
-        "1991-05-20 11:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
-      );
-      clock.tick(time.toDate().getTime());
+      describe("after the first shout", () => {
+        it("before the second-shout time, schedules a second-shout", async () => {
+          // Monday, May 20, 1991: Michael Jordan named NBA MVP.
+          const time = moment.tz(
+            "1991-05-20 11:00:00",
+            process.env.ANGRY_TOCK_TIMEZONE
+          );
+          clock.tick(time.toDate().getTime());
 
-      const angryTock = await load();
-      angryTock(app);
+          const angryTock = await load();
+          angryTock(app);
 
-      time.hour(14);
-      time.minute(45);
-      expect(scheduleJob).toHaveBeenCalledWith(
-        time.toDate(),
-        expect.any(Function)
-      );
-    });
+          time.hour(14);
+          time.minute(45);
+          expect(scheduleJob).toHaveBeenCalledWith(
+            time.toDate(),
+            expect.any(Function)
+          );
+        });
 
-    it("if it is shouty day, after the second-shout time, schedules a first-shout for the next shouty day", async () => {
-      // Monday, January 20, 1997 - Bill Clinton is sworn into his second term
-      // as President of the United States.
-      // Angry Tock is not location aware, but inauguration day is a holiday for
-      // DC-area federal employees. So... just a note for the future!
-      const initial = moment.tz(
-        "1997-01-27 20:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
-      );
-      clock.tick(initial.toDate().getTime());
+        it("after the second-shout time, schedules a first-shout for the next shouty day", async () => {
+          // Monday, January 20, 1997 - Bill Clinton is sworn into his second term
+          // as President of the United States.
+          // Angry Tock is not location aware, but inauguration day is a holiday for
+          // DC-area federal employees. So... just a note for the future!
+          const initial = moment.tz(
+            "1997-01-27 20:00:00",
+            process.env.ANGRY_TOCK_TIMEZONE
+          );
+          clock.tick(initial.toDate().getTime());
 
-      const angryTock = await load();
-      angryTock(app);
+          const angryTock = await load();
+          angryTock(app);
 
-      // Monday, February 3, 1997 - Cornell University faculty, staff, and
-      // students gathered for a public memorial for Carl Sagan.
-      const scheduled = moment.tz(
-        "1997-02-03 10:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
-      );
-      expect(scheduleJob).toHaveBeenCalledWith(
-        scheduled.toDate(),
-        expect.any(Function)
-      );
+          // Monday, February 3, 1997 - Cornell University faculty, staff, and
+          // students gathered for a public memorial for Carl Sagan.
+          const scheduled = moment.tz(
+            "1997-02-03 10:00:00",
+            process.env.ANGRY_TOCK_TIMEZONE
+          );
+          expect(scheduleJob).toHaveBeenCalledWith(
+            scheduled.toDate(),
+            expect.any(Function)
+          );
+        });
+      });
     });
 
     it("if it is not shouty, schedules a first-shout for the next shouty day", async () => {
@@ -281,8 +285,7 @@ describe("Angry Tock", () => {
           fallback:
             "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
           color: "#FF0000",
-          text:
-            "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
+          text: "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
         },
       ],
       username: "Angry Tock",

--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -123,30 +123,12 @@ describe("Angry Tock", () => {
 
   describe("schedules the next shouting match on startup", () => {
     describe("if it is a shouty day", () => {
-      it("before first-shout time, schedules a first-shout", async () => {
-        // Monday, April 8, 1974: Hank Aaron hits his 715th career homerun,
-        // breaking Babe Ruth's record.
-        const time = moment.tz(
-          "1974-04-08 00:00:00",
-          process.env.ANGRY_TOCK_TIMEZONE
-        );
-        clock.tick(time.toDate().getTime());
-
-        const angryTock = await load();
-        angryTock(app);
-
-        time.hour(10);
-        expect(scheduleJob).toHaveBeenCalledWith(
-          time.toDate(),
-          expect.any(Function)
-        );
-      });
-
-      describe("after the first shout", () => {
-        it("before the second-shout time, schedules a second-shout", async () => {
-          // Monday, May 20, 1991: Michael Jordan named NBA MVP.
+      describe("before the first shout time", () => {
+        it("schedules a first-shout", async () => {
+          // Monday, April 8, 1974: Hank Aaron hits his 715th career homerun,
+          // breaking Babe Ruth's record.
           const time = moment.tz(
-            "1991-05-20 11:00:00",
+            "1974-04-08 00:00:00",
             process.env.ANGRY_TOCK_TIMEZONE
           );
           clock.tick(time.toDate().getTime());
@@ -154,65 +136,91 @@ describe("Angry Tock", () => {
           const angryTock = await load();
           angryTock(app);
 
-          time.hour(14);
-          time.minute(45);
+          time.hour(10);
           expect(scheduleJob).toHaveBeenCalledWith(
             time.toDate(),
             expect.any(Function)
           );
         });
+      });
 
-        it("after the second-shout time, schedules a first-shout for the next shouty day", async () => {
-          // Monday, January 20, 1997 - Bill Clinton is sworn into his second term
-          // as President of the United States.
-          // Angry Tock is not location aware, but inauguration day is a holiday for
-          // DC-area federal employees. So... just a note for the future!
-          const initial = moment.tz(
-            "1997-01-27 20:00:00",
-            process.env.ANGRY_TOCK_TIMEZONE
-          );
-          clock.tick(initial.toDate().getTime());
+      describe("after the first shout", () => {
+        describe("before the second shout time", () => {
+          it("schedules a second-shout", async () => {
+            // Monday, May 20, 1991: Michael Jordan named NBA MVP.
+            const time = moment.tz(
+              "1991-05-20 11:00:00",
+              process.env.ANGRY_TOCK_TIMEZONE
+            );
+            clock.tick(time.toDate().getTime());
 
-          const angryTock = await load();
-          angryTock(app);
+            const angryTock = await load();
+            angryTock(app);
 
-          // Monday, February 3, 1997 - Cornell University faculty, staff, and
-          // students gathered for a public memorial for Carl Sagan.
-          const scheduled = moment.tz(
-            "1997-02-03 10:00:00",
-            process.env.ANGRY_TOCK_TIMEZONE
-          );
-          expect(scheduleJob).toHaveBeenCalledWith(
-            scheduled.toDate(),
-            expect.any(Function)
-          );
+            time.hour(14);
+            time.minute(45);
+            expect(scheduleJob).toHaveBeenCalledWith(
+              time.toDate(),
+              expect.any(Function)
+            );
+          });
+        });
+
+        describe("after the second shout time", () => {
+          it("schedules a first-shout for the next shouty day", async () => {
+            // Monday, January 20, 1997 - Bill Clinton is sworn into his second term
+            // as President of the United States.
+            // Angry Tock is not location aware, but inauguration day is a holiday for
+            // DC-area federal employees. So... just a note for the future!
+            const initial = moment.tz(
+              "1997-01-27 20:00:00",
+              process.env.ANGRY_TOCK_TIMEZONE
+            );
+            clock.tick(initial.toDate().getTime());
+
+            const angryTock = await load();
+            angryTock(app);
+
+            // Monday, February 3, 1997 - Cornell University faculty, staff, and
+            // students gathered for a public memorial for Carl Sagan.
+            const scheduled = moment.tz(
+              "1997-02-03 10:00:00",
+              process.env.ANGRY_TOCK_TIMEZONE
+            );
+            expect(scheduleJob).toHaveBeenCalledWith(
+              scheduled.toDate(),
+              expect.any(Function)
+            );
+          });
         });
       });
     });
 
-    it("if it is not shouty, schedules a first-shout for the next shouty day", async () => {
-      // Friday, October 18, 2019 - First all-female spacewalk conducted by NASA
-      // astronauts Christina Koch and Jessica Meir outside of the Internaional
-      // Space Station.
-      const initial = moment.tz(
-        "2019-10-18 09:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
-      );
-      clock.tick(initial.toDate().getTime());
+    describe("if it is not a shouty day", () => {
+      it("schedules a first-shout for the next shouty day", async () => {
+        // Friday, October 18, 2019 - First all-female spacewalk conducted by NASA
+        // astronauts Christina Koch and Jessica Meir outside of the Internaional
+        // Space Station.
+        const initial = moment.tz(
+          "2019-10-18 09:00:00",
+          process.env.ANGRY_TOCK_TIMEZONE
+        );
+        clock.tick(initial.toDate().getTime());
 
-      const angryTock = await load();
-      angryTock(app);
+        const angryTock = await load();
+        angryTock(app);
 
-      // Monday, October 21, 2019 - World's oldest natural pearl, dated at 8,000
-      // years old, is found new Abu Dhabi.
-      const scheduled = moment.tz(
-        "2019-10-21 10:00:00",
-        process.env.ANGRY_TOCK_TIMEZONE
-      );
-      expect(scheduleJob).toHaveBeenCalledWith(
-        scheduled.toDate(),
-        expect.any(Function)
-      );
+        // Monday, October 21, 2019 - World's oldest natural pearl, dated at 8,000
+        // years old, is found new Abu Dhabi.
+        const scheduled = moment.tz(
+          "2019-10-21 10:00:00",
+          process.env.ANGRY_TOCK_TIMEZONE
+        );
+        expect(scheduleJob).toHaveBeenCalledWith(
+          scheduled.toDate(),
+          expect.any(Function)
+        );
+      });
     });
   });
 

--- a/src/scripts/federal-holidays-reminder.js
+++ b/src/scripts/federal-holidays-reminder.js
@@ -26,10 +26,10 @@ const previousWeekday = (date) => {
   return source;
 };
 
-const postReminder = (holiday) => {
+const postReminder = async (holiday) => {
   const emoji = emojis.get(holiday.name);
 
-  postMessage({
+  await postMessage({
     channel: CHANNEL,
     text: `@here Remember that *${holiday.date.format(
       "dddd"
@@ -40,14 +40,14 @@ const postReminder = (holiday) => {
 };
 
 const scheduleReminder = () => {
-  const nextHoliday = module.exports.getNextHoliday(TIMEZONE);
-  const target = module.exports.previousWeekday(nextHoliday.date);
+  const nextHoliday = getNextHoliday(TIMEZONE);
+  const target = previousWeekday(nextHoliday.date);
 
   target.hour(reportingTime.hour());
   target.minute(reportingTime.minute());
 
-  scheduler.scheduleJob(target.toDate(), () => {
-    module.exports.postReminder(nextHoliday);
+  scheduler.scheduleJob(target.toDate(), async () => {
+    await postReminder(nextHoliday);
 
     // Tomorrow, schedule the next holiday reminder
     scheduler.scheduleJob(target.add(1, "day").toDate(), () => {
@@ -57,8 +57,3 @@ const scheduleReminder = () => {
 };
 
 module.exports = scheduleReminder;
-
-// Expose for testing
-module.exports.getNextHoliday = getNextHoliday;
-module.exports.postReminder = postReminder;
-module.exports.previousWeekday = previousWeekday;

--- a/src/scripts/federal-holidays-reminder.test.js
+++ b/src/scripts/federal-holidays-reminder.test.js
@@ -32,12 +32,14 @@ describe("holiday reminder", () => {
       it("defaults to 15:00", async () => {
         const bot = await load();
 
-        const nextHoliday = { date: moment("2021-08-16T12:00:00Z") };
+        const nextHoliday = {
+          date: moment.tz("2021-08-16T12:00:00", "America/New_York"),
+        };
         getNextHoliday.mockReturnValue(nextHoliday);
 
         bot();
         expect(scheduleJob).toHaveBeenCalledWith(
-          new Date(Date.parse("2021-08-13T15:00:00-0500")),
+          moment(nextHoliday.date).subtract(3, "days").hour(15).toDate(),
           expect.any(Function)
         );
       });
@@ -46,12 +48,18 @@ describe("holiday reminder", () => {
         process.env.HOLIDAY_REMINDER_TIME = "04:32";
         const bot = await load();
 
-        const nextHoliday = { date: moment("2021-08-16T12:00:00Z") };
+        const nextHoliday = {
+          date: moment.tz("2021-08-16T12:00:00", "America/New_York"),
+        };
         getNextHoliday.mockReturnValue(nextHoliday);
 
         bot();
         expect(scheduleJob).toHaveBeenCalledWith(
-          new Date(Date.parse("2021-08-13T04:32:00-0500")),
+          moment(nextHoliday.date)
+            .subtract(3, "days")
+            .hour(4)
+            .minute(32)
+            .toDate(),
           expect.any(Function)
         );
       });
@@ -66,7 +74,7 @@ describe("holiday reminder", () => {
 
         bot();
         expect(scheduleJob).toHaveBeenCalledWith(
-          new Date(Date.parse("2021-08-18T15:00:00-0500")),
+          moment(nextHoliday.date).subtract(1, "day").hour(15).toDate(),
           expect.any(Function)
         );
       });
@@ -80,7 +88,11 @@ describe("holiday reminder", () => {
 
         bot();
         expect(scheduleJob).toHaveBeenCalledWith(
-          new Date(Date.parse("2021-08-18T04:32:00-0500")),
+          moment(nextHoliday.date)
+            .subtract(1, "day")
+            .hour(4)
+            .minute(32)
+            .toDate(),
           expect.any(Function)
         );
       });
@@ -88,11 +100,13 @@ describe("holiday reminder", () => {
   });
 
   describe("posts a reminder", () => {
+    const date = moment.tz("2021-08-19T12:00:00", "America/New_York");
+
     const getReminderFn = async (holiday = "test holiday") => {
       const bot = await load();
 
       const nextHoliday = {
-        date: moment("2021-08-19T12:00:00Z"),
+        date,
         name: holiday,
       };
       getNextHoliday.mockReturnValue(nextHoliday);
@@ -111,9 +125,12 @@ describe("holiday reminder", () => {
         text: "@here Remember that *Thursday* is a federal holiday in observance of *test holiday*!",
       });
 
-      // Sets up a job for tomorrow to schedule the next reminder
+      // Sets up a job for tomorrow to schedule the next reminder. Because the
+      // scheduled job above runs the day before the holiday, this upcoming job
+      // (1 day later) will be ON the holiday, at 15:00. This logic is the same
+      // for the subsequent tests below.
       expect(scheduleJob).toHaveBeenCalledWith(
-        new Date(Date.parse("2021-08-19T15:00:00-0500")),
+        moment(date).hour(15).toDate(),
         expect.any(Function)
       );
     });
@@ -130,7 +147,7 @@ describe("holiday reminder", () => {
 
       // Sets up a job for tomorrow to schedule the next reminder
       expect(scheduleJob).toHaveBeenCalledWith(
-        new Date(Date.parse("2021-08-19T15:00:00-0500")),
+        moment(date).hour(15).toDate(),
         expect.any(Function)
       );
     });
@@ -146,7 +163,7 @@ describe("holiday reminder", () => {
 
       // Sets up a job for tomorrow to schedule the next reminder
       expect(scheduleJob).toHaveBeenCalledWith(
-        new Date(Date.parse("2021-08-19T15:00:00-0500")),
+        moment(date).hour(15).toDate(),
         expect.any(Function)
       );
     });
@@ -162,7 +179,7 @@ describe("holiday reminder", () => {
 
       nextSchedule();
       expect(scheduleJob).toHaveBeenCalledWith(
-        new Date(Date.parse("2021-08-31T15:00:00-0500")),
+        moment(nextHoliday.date).subtract(1, "day").hour(15).toDate(),
         expect.any(Function)
       );
     });


### PR DESCRIPTION
- reorganize the Angry Tock tests so there are fewer "and"s in the test descriptions
- gets rid of tests that test internal functionality of the holiday reminder script because that's a bad practice

closes #261 