### PR TITLE
Proposal: Make encouragement bot trigger less frequently

### DIFF
--- a/src/scripts/encourage-bot.js
+++ b/src/scripts/encourage-bot.js
@@ -118,7 +118,7 @@ const scheduleAnotherReminder = async (app, channel, time) => {
     while (holidays.isAHoliday(next.toDate())) {
       next.add(1, "day");
     }
-    q;
+
     // The new time could also have been on the weekend, or we could have been
     // advanced to the weekend by a Friday holiday, so make sure we bustle out of
     // those, too.


### PR DESCRIPTION
This PR updates encouragement bot so that it only posts randomly once every 7 to 28 days. The idea is that it should feel kind of out-of-nowhere.

I'm not convinced this bot is a good one. The idea of randomly encouraging people is good, but I'm not sure it has any sort of value when it's coming from a bot instead of coming from real people.

Also moves the timezone diff calculation to after the next date is chosen, so it can account for daylight savings if necessary.