### PR TITLE
Tweak lovin.gov trigger regex

### DIFF
--- a/config/slack-random-response.json
+++ b/config/slack-random-response.json
@@ -74,7 +74,7 @@
   {
     "botName": "Lovin.gov Bot",
     "defaultEmoji": ":lovin-gov:",
-    "trigger": "need me some lovin.gov",
+    "trigger": "need me some (<http://lovin.gov\\|)?lovin.gov",
     "responseUrl": "https://raw.githubusercontent.com/18F/18f-bot-facts/main/lovin-gov.json"
   }
 ]


### PR DESCRIPTION
Slack automatically transforms `lovin.gov` into a link, which is then sent in the message as `<http://lovin.gov|lovin.gov>`. This PR updates the trigger regex to account for that link-ification. Makes the the linky part optional in the regex in case there is a Slack client that _doesn't_ do the transformation for some reason.