### PR TITLE
Dad Joke bot setup fix

### DIFF
--- a/src/scripts/dad-joke.js
+++ b/src/scripts/dad-joke.js
@@ -39,7 +39,7 @@ module.exports = (app) => {
             icon_emoji: ":dog-joke:",
             text: joke.punchline,
             thread_ts: thread,
-            username: "Jed Bartlett",
+            username: "Jed \u200bBartlett",
           });
         }, 5000);
       }

--- a/src/scripts/dad-joke.test.js
+++ b/src/scripts/dad-joke.test.js
@@ -138,7 +138,7 @@ describe("dad jokes (are the best worst)", () => {
           icon_emoji: ":dog-joke:",
           text: "the funny part",
           thread_ts: "thread id",
-          username: "Jed Bartlett",
+          username: "Jed \u200bBartlett",
         });
       });
     });


### PR DESCRIPTION
Just changing the avatar between messages does not guarantee that it will display separately; the username for the response must change too. But we want Jed Bartlett to be the username for both! So... insert a zero-width space into the username for the response so that it's technically different but you can't tell.