### PR TITLE
You know what's fun? A dozen pull requests testing a CI/CD thing

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819
       - run: gh pr review "$GITHUB_HEAD_REF" --approve
-      - run: gh pr merge "$GITHUB_HEAD_REF" --auto
+      - run: gh pr merge "$GITHUB_HEAD_REF" --auto --squash


### PR DESCRIPTION
It turns out that when using the GitHub CLI non-interactively and you tell it to merge a PR, you have to tell it what merging strategy to use. Which totally makes sense, but... it's not documented. 🙁 