### PR TITLE
Add word boundary and plural support to the random fact filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "moment": "^2.27.0",
         "moment-timezone": "^0.5.32",
         "node-schedule": "^2.0.0",
-        "pg": "^8.7.1"
+        "pg": "^8.7.1",
+        "plural": "^1.1.0"
       },
       "devDependencies": {
         "eslint": "^8.1.0",
@@ -31,7 +32,7 @@
         "prettier": "^2.3.2"
       },
       "engines": {
-        "node": "^16.13.0"
+        "node": "^16.10.0"
       }
     },
     "node_modules/@18f/us-federal-holidays": {
@@ -5698,6 +5699,11 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "node_modules/plural": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/plural/-/plural-1.1.0.tgz",
+      "integrity": "sha512-kX459gcOOllXDCPolRRBItCjvWU4bULIg4R3OYRMAp/4mZuBfF/H7b/SBsTJZkyc+GFkJV4ENitITOz45kyzqQ=="
+    },
     "node_modules/ports": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ports/-/ports-1.1.0.tgz",
@@ -11356,6 +11362,11 @@
       "requires": {
         "semver-compare": "^1.0.0"
       }
+    },
+    "plural": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/plural/-/plural-1.1.0.tgz",
+      "integrity": "sha512-kX459gcOOllXDCPolRRBItCjvWU4bULIg4R3OYRMAp/4mZuBfF/H7b/SBsTJZkyc+GFkJV4ENitITOz45kyzqQ=="
     },
     "ports": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "moment": "^2.27.0",
     "moment-timezone": "^0.5.32",
     "node-schedule": "^2.0.0",
-    "pg": "^8.7.1"
+    "pg": "^8.7.1",
+    "plural": "^1.1.0"
   },
   "engines": {
     "node": "^16.10.0"

--- a/src/scripts/random-responses.js
+++ b/src/scripts/random-responses.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const fs = require("fs");
+const plural = require("plural");
 const { cache } = require("../utils");
 
 const loadConfigs = async () =>
@@ -33,13 +34,28 @@ const getResponses = async (config, searchTerm = false) => {
   }
 
   if (searchTerm) {
-    const regex = new RegExp(searchTerm, "i");
-    const filtered = responses.filter((r) => {
+    const regex = new RegExp(
+      `\\b(${searchTerm}|${plural(searchTerm)})\\b`,
+      "i"
+    );
+    let filtered = responses.filter((r) => {
       if (typeof r === "object") {
         return regex.test(`${r.name} ${r.emoji} ${r.text}`);
       }
       return regex.test(r);
     });
+    if (filtered.length === 0) {
+      const embeddedRegex = new RegExp(
+        `(${searchTerm}|${plural(searchTerm)})`,
+        "i"
+      );
+      filtered = responses.filter((r) => {
+        if (typeof r === "object") {
+          return embeddedRegex.test(`${r.name} ${r.emoji} ${r.text}`);
+        }
+        return embeddedRegex.test(r);
+      });
+    }
     if (filtered.length > 0) {
       responses = filtered;
     }

--- a/src/scripts/random-responses.test.js
+++ b/src/scripts/random-responses.test.js
@@ -172,28 +172,63 @@ describe("random responder", () => {
       expect(responses).toEqual([]);
     });
 
-    it("filters messages if provided a search term", async () => {
-      const responses = await script.getResponses(
-        {
-          responseList: [
-            "message one",
-            "message two",
-            "one message",
-            { name: "one message", emoji: "four", text: "four" },
-            { name: "five message", emoji: "one", text: "five" },
-            { name: "message six", emoji: "six", text: "one" },
-            { name: "message seven", emoji: "seven", text: "seven" },
-          ],
-        },
-        "one"
-      );
-      expect(responses).toEqual([
-        "message one",
-        "one message",
-        { name: "one message", emoji: "four", text: "four" },
-        { name: "five message", emoji: "one", text: "five" },
-        { name: "message six", emoji: "six", text: "one" },
-      ]);
+    describe("filters messages if provided a search term", () => {
+      it("includes messages where the search term is exactly present", async () => {
+        const responses = await script.getResponses(
+          {
+            responseList: [
+              "message one",
+              "message two",
+              "one message",
+              { name: "one message", emoji: "four", text: "four" },
+              { name: "five message", emoji: "one", text: "five" },
+              { name: "message six", emoji: "six", text: "one" },
+              { name: "message seven", emoji: "seven", text: "seven" },
+            ],
+          },
+          "one"
+        );
+        expect(responses).toEqual([
+          "message one",
+          "one message",
+          { name: "one message", emoji: "four", text: "four" },
+          { name: "five message", emoji: "one", text: "five" },
+          { name: "message six", emoji: "six", text: "one" },
+        ]);
+      });
+
+      it("also happily includes plural versions of search terms", async () => {
+        const responses = await script.getResponses(
+          { responseList: ["this is a hat", "these are hats"] },
+          "hat"
+        );
+        expect(responses).toEqual(["this is a hat", "these are hats"]);
+      });
+
+      it("excludes messages where the search term is only embedded in another word", async () => {
+        const responses = await script.getResponses(
+          { responseList: ["this is a hat", "that is not"] },
+          "hat"
+        );
+        expect(responses).toEqual(["this is a hat"]);
+      });
+
+      it("falls back to including embedded words if non-embedded words come up empty", async () => {
+        const responses = await script.getResponses(
+          {
+            responseList: [
+              "this is a cap",
+              "that is not",
+              { name: "chapeau", emoji: "tophat", text: "fancy" },
+            ],
+          },
+          "hat"
+        );
+        expect(responses).toEqual([
+          "that is not",
+          { name: "chapeau", emoji: "tophat", text: "fancy" },
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
Major kudos to @bengerman13 for figuring this one out.

Now if you say `hat dog fact`, it will first try to find facts that include just `hat`, not `that`. It will fall back to the more inclusive version if the more restrictive search fails. It will also look for plurals, which is pretty cool!