### PR TITLE
Fix a bug where coffeemate matches too aggressively

### DIFF
--- a/src/scripts/coffeemate.js
+++ b/src/scripts/coffeemate.js
@@ -11,7 +11,7 @@ const baseResponse = {
 };
 
 module.exports = (app) => {
-  app.message(/coffee me( \S+$)?/i, async (message) => {
+  app.message(/coffee me(\s+|$)/i, async (message) => {
     const {
       context: {
         matches: [, scopeMatch],

--- a/src/scripts/coffeemate.test.js
+++ b/src/scripts/coffeemate.test.js
@@ -18,7 +18,7 @@ describe("coffeemate", () => {
     coffeemate(app);
 
     expect(app.message).toHaveBeenCalledWith(
-      /coffee me( \S+$)?/i,
+      /coffee me(\s+|$)/i,
       expect.any(Function)
     );
   });


### PR DESCRIPTION
Previously, coffeemate would trigger on `coffee meeting`, but that's... wrong. This tweaks the regex that it's listening for so that it only matches `coffee me`.