### PR TITLE
`define` matches terms more flexibly

### DIFF
--- a/src/scripts/define.js
+++ b/src/scripts/define.js
@@ -17,18 +17,23 @@ const he = require("he");
 const yaml = require("js-yaml");
 const { cache } = require("../utils");
 
+
+/**
+ * Turn a string into a search slug, removing all non-word characters (including spaces and punctuation).
+ */
+const slugify = (term) => term.replaceAll(/\W/ig, '').toLowerCase();
+
 /**
  * Find a string in a list of strings, ignoring case.
  * @param list [Array<String>] List of strings (the haystack)
  * @param searchTerm [String] The term to find (the needle)
  * @return [String | null] The canonical key for the found term
  */
-
 const findCaseInsensitively = (list, searchTerm) => {
-  const lowerSearch = searchTerm.toLowerCase();
+  const lowerSearch = slugify(searchTerm);
   for (let i = 0; i < list.length; i += 1) {
     const term = list[i];
-    if (term.toLowerCase() === lowerSearch) {
+    if (slugify(term) === lowerSearch) {
       return term;
     }
   }

--- a/src/scripts/define.test.js
+++ b/src/scripts/define.test.js
@@ -14,6 +14,10 @@ const glossaryData = {
       "type": "term",
       "description": "ADR includes dispute resolution processes and techniques that fall outside of the government judicial process."
   },
+  "Back end developer": {
+      "type": "term",
+      "description": "The people who write the code for the parts of a web site you don't see, working in programming languages like Ruby, Python, or NodeJS. They work on pieces of the application that, for example:\n- Generate shopping recommendations\n- Gather all of the information for search to work\n- Trigger emails being sent"
+  },
   "POP": {
       "type": "acronym",
       "term": [
@@ -92,6 +96,36 @@ describe("glossary", () => {
         );
       });
     })
+
+    describe("fuzzy-matching entries", () => {
+      const backendResponse = "*Back end developer*: The people who write the code for the parts of a web site you don't see, working in programming languages like Ruby, Python, or NodeJS. They work on pieces of the application that, for example:\n- Generate shopping recommendations\n- Gather all of the information for search to work\n- Trigger emails being sent"
+
+      describe("with an exact match", () => {
+        const message = buildSearchMessage("back end developer");
+        it("returns the correct definitions", async () => {
+          await handler(message);
+          expect(message.say).toHaveBeenCalledWith(expectedResponse(backendResponse));
+        });
+      });
+
+      describe("with a dash", () => {
+        const message = buildSearchMessage("back-end developer")
+
+        it("returns the correct definitions", async () => {
+          await handler(message);
+          expect(message.say).toHaveBeenCalledWith(expectedResponse(backendResponse));
+        });
+      });
+
+      describe("with no space", () => {
+        const message = buildSearchMessage("backend developer")
+
+        it("returns the correct definitions", async () => {
+          await handler(message);
+          expect(message.say).toHaveBeenCalledWith(expectedResponse(backendResponse));
+        });
+      });
+    });
 
     describe("finding an entry", () => {
       describe("of type 'term'", () => {


### PR DESCRIPTION
Previously, searching `backend developer` to find `back end developer` didn't work. Now it does, by ignoring all non-alphanumeric characters in the search string.

Fixes #388 