### PR TITLE
Add a static menu for A11y and change commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ facts. There are just so many facts. You can just say `dog fact` (or
 | ----------------- | ------------------------------------------------- |
 | `alan fact`       | Shares a fact about people named Alan             |
 | `alumni dog fact` | Shares a fact about a dog belonging to a TTS alum |
-| `ask ally`        | Shares a fact about accessible web development    |
+| `ask ally fact`   | Shares a fact about accessible web development    |
 | `cat fact`        | Shares a fact about a TTS person's cat            |
 | `dog fact`        | Shares a fact about a TTS person's dog            |
 | `dolphin fact`    | Shares a fact about dolphins                      |

--- a/config/slack-random-response.json
+++ b/config/slack-random-response.json
@@ -86,7 +86,7 @@
   {
     "botName": "Ally the A11ybot",
     "defaultEmoji": ":a11y-ally:",
-    "trigger": "ask a(11|ll)y",
+    "trigger": "ask a(11|ll)y fact",
     "responseUrl": "https://raw.githubusercontent.com/18F/charlie-slack-bot-facts/main/a11y-facts.json"
   },
   {

--- a/src/scripts/a11y.js
+++ b/src/scripts/a11y.js
@@ -1,0 +1,43 @@
+module.exports = (app) => {
+  app.message(/ask a(11|ll)y+$/i, async ({ say }) => {
+    say({
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "*Here are some things you can type in Slack that A11yBot can respond to*"
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "*ask a11y fact*"
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "_This will return a random accessibility resource or fact_"
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "*ask a11y*"
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "_Returns a list of commands that a11y can respond to_"
+          }
+        }
+      ]
+    });
+  });
+};

--- a/src/scripts/a11y.test.js
+++ b/src/scripts/a11y.test.js
@@ -1,0 +1,67 @@
+const { getApp } = require("../utils/test");
+
+const a11y = require("./a11y");
+
+describe("ask a11y", () => {
+  const app = getApp();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("registers the message handlers", () => {
+    a11y(app);
+    expect(app.message).toHaveBeenCalledWith(
+      /ask a(11|ll)y+$/i,
+      expect.any(Function)
+    );
+  });
+
+  it("returns content", () => {
+    a11y(app);
+    const handler = app.getHandler(0);
+    const say = jest.fn();
+
+    handler({ say });
+    
+    expect(say).toHaveBeenCalledWith({
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "*Here are some things you can type in Slack that A11yBot can respond to*"
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "*ask a11y fact*"
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "_This will return a random accessibility resource or fact_"
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "*ask a11y*"
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "_Returns a list of commands that a11y can respond to_"
+          }
+        }
+      ]
+    });
+  });
+});


### PR DESCRIPTION
This pr does two small things to set the foundation for more work on A11yBot. 

-    "ask ally or ask a11y" will now return the menu, which is about to grow as we add functionality.
-    The original "ask ally" functionality of returning a random fact now requires the command "ask ally fact".

![790e24c6191f3b93](https://user-images.githubusercontent.com/93271895/156795509-fa117d4d-84ef-44d9-adda-9f91026f806b.png)
 