### PR TITLE
Add MANY more Q-Expander titles

### DIFF
--- a/config/q-expand.csv
+++ b/config/q-expand.csv
@@ -1,4 +1,5 @@
 stub,desc
+Q,FAS (TTS)
 Q0A,Chief of Staff
 Q1,Deputy Commissioner
 Q1B,QSMO for Civilian HR Trans & N

--- a/config/q-expand.csv
+++ b/config/q-expand.csv
@@ -1,44 +1,446 @@
 stub,desc
-Q,FAS (TTS)
+Q0A,Chief of Staff
+Q1,Deputy Commissioner
+Q1B,QSMO for Civilian HR Trans & N
 Q2,TTS
-QU,Office of Clients & Markets
-QQ,Office of Solutions
-QUA,Presidential Innovation Fellows
-QUB,Centers of Excellence
-QUC,Outreach
-QUD,Client Development
-QUE,18F
-QQ1,Cloud.gov
-QQ2,Login.gov
-QQ3,IT Portfolio
-QQA,Data & Analytics
-QQB,Public Experience
-QQC,Secure Cloud
-QQD,Smarter IT
-QQE,Innovation
-QQF,Business Management/10X
-QQG,MAX.gov & Identity
-QQH,Artificial Intelligence
-QQBA,Content & Outreach
-QQBB,Customer Experience
-QQBC,Delivery & Channel Ops
-QQCA,Branch A
-QQCB,Branch B
-QQGA,Branch A
-QQGB,Branch B
-QQHA,ARP
-QQHB,USDC
 Q20A,Acquisition Division
-Q20B,Business Operations Division
 Q20AA,Procurement Analyst
 Q20AB,Contract Specialist
+Q20B,Business Operations Division
 Q20BA,Finance
 Q20BB,Agreements
 Q20BC,People Ops
 Q20BD,Talent
+QC,FAS/Ofc of Cust & Stkhldr Enga
+QC1,Ofc of Dep Asst Comm Engmnt Ou
+QC1D,Partner Engagement & Acq. Trng
+QC1DA,Branch A
+QC1DB,Branch B
+QC1E,Digital Outreach and Communica
+QC1EA,Branch A
+QC1EB,Branch B
+QC1F,Mgmt and Program Support Divis
+QC2,Ofc of Dep Asst Comm Stkhldr A
+QC2A,Natl Account Mgmt Strategy Div
+QC2AA,Branch A
+QC2AB,Branch B
+QC2C,Cust. Intel. Mgmt. & Analysis
+QC2CA,Branch A
+QC2CB,Branch B
+QD,FAS/Office of Systems Manageme
+QD0A,Management and Program Support
+QD0AA,Branch A
+QD0AB,Branch B
+QD1,Ofc of Dep Asst Comm Systms Tr
+QD1E,Transformation Division
+QD1EA,Branch A
+QD1EB,Branch B
+QD1F,Operations Division
+QD2,Ofc of Dep Asst Comm  IAE/SAM
+QD2B,Business Applications Operatio
+QD2C,Outreach & Stkhldr Engagement
+QD2CA,Branch A
+QD2CB,Branch B
+QF,FAS/Ofc of Assisted Acquisitio
+QF0A,Business Operations Division
+QF0B,Center for FEDSIM
+QF0B1,Deputy Director
+QF0B1B,Branch A
+QF0B1BA,Section 1
+QF0B1BB,Section 2
+QF0B1BC,Section 3
+QF0B1BD,Section 4
+QF0B1C,Branch B
+QF0B1CA,Section 1
+QF0B1CB,Section 2
+QF0B1CC,Section 3
+QF0B1CD,Section 4
+QF0B1D,Branch C
+QF0B1DA,Section 1
+QF0B1DB,Section 2
+QF0B1DC,Section 3
+QF0B1DD,Section 4
+QF0B1DE,Section 5
+QF0B1E,Branch D
+QF0B1EA,Section 1
+QF0B1EB,Section 2
+QF0B1EC,Section 3
+QF0B1ED,Section 4
+QF0B1EE,Section 5
+QF0B1EF,Section 6
+QF0B1FA,Section 1
+QF0B1FB,Section 2
+QF0B1FC,Section 3
+QF0B1FD,Section 4
+QF0B1GA,Section 1
+QF0B1GB,Section 2
+QF0B1GC,Section 3
+QF0B1HA,Section 1
+QF0B1HB,Section 2
+QF0B1IA,Section 1
+QF0B1IB,Section 2
+QF0B1ID,Section 4
+QF0BA,Mgmt & Program Support Divisio
+QF0BAA,Branch A
+QF0BAB,Branch B
+QF0BAC,Branch C
+QF0C,Program Management Division
+QF1,Ofc of the Deputy Asst Commiss
+QM,FAS/Ofc of Trvl Trans & Log Ca
+QM0A,Management & Program Support S
+QMA,Office of Acquisition Operatio
+QMAA,Center for Vehicle Acquisition
+QMAAA,Branch A
+QMAAB,Branch B
+QMAAC,Branch C
+QMAACA,Section 1
+QMAACB,Section 2
+QMAC,Ctr for Travel & Transportatio
+QMACA,Branch A
+QMACB,Branch B
+QMC,Ofc of Trvl Employee Relo & Tr
+QMC1,Deputy - Ofc of Trvl - Emp Reloc
+QMC1A,City Pairs Program Division
+QMC1B,Lodging - Innov. Sol & Schedule
+QMC1C,E-Gov Travel Division
+QMCA,Transportation Audits Division
+QMCAA,Branch A
+QMCAAA,Section 1
+QMCAAB,Section 2
+QMCAB,Branch B
+QMCAC,Branch C
+QMCB,Strat. Plng - Bus. Mgmt & Admin
+QMCC,Transportation Management Divi
+QMCG,Emp Relocation Resource Center
+QMD,Office of Fleet Management
+QMDA,Purchasing Division
+QMDAA,Engineering Branch
+QMDAB,Contract and Supply Management
+QMDAD,Quality Assurance Branch
+QMDC,Business Management Division
+QMDCA,Business Intelligence Branch
+QMDCAA,Card Services Section
+QMDCB,Business Oversight Branch
+QMDD,Offering Support Division
+QMDDA,Offering Management Branch
+QMDDB,Ordering Management Branch
+QMDDC,Consolidations and Fleet Servi
+QMDDD,Short-term Rental Branch
+QMDE,Product Integration Division
+QMDEA,Operations and Maintenance Bra
+QMDEB,Product Integration Branch
+QMDF,Vehicle Management Division
+QMDFA,Maintenance & Accident Managem
+QMDFAA,Accident Mgmt Center (Atlanta)
+QMDFAB,Accident Mgmt Center (Kansas C
+QMDFAC,Maint Control Center (Atlanta)
+QMDFAD,Maint Control Center (Ft Worth
+QMDFAE,Maintenance Control Center (LO
+QMDFD,Vehicle Management Branch
+QMDG,Marketplace and Innovation Div
+QMDGA,Marketplace Branch
+QMDGB,Innovation Branch
+QMDH,Mgmt and Program Support Divis
+QMDZ,Ofc of the Deputy Dir - Zonal O
+QMDZ1,Zone 1
+QMDZ1FC,Branch C
+QMDZ1FCA,San Juan Fleet Mgmt Center
+QMDZ1FCB,European Fleet Mgmt Center
+QMDZ1FCC,DC Metro Fleet Management Cent
+QMDZ1FO,Branch B
+QMDZ1FOA,Manchester Fleet Management Ce
+QMDZ1FOB,Hartford Fleet Mgmt Center
+QMDZ1FOC,New York Metro Fleet Mgmt Cent
+QMDZ1FOD,Buffalo Fleet Mgmt Center
+QMDZ1FOF,Pittsburgh Fleet Management Ce
+QMDZ1FOG,Baltimore Fleet Management Cen
+QMDZ1FOI,Norfolk Fleet Management Cente
+QMDZ1FS,Branch A
+QMDZ1FSA,Section 1
+QMDZ1FSS,Section 2
+QMDZ2,Zone 2
+QMDZ2FO,Branch B
+QMDZ2FOA,Atlanta Fleet Management Cente
+QMDZ2FOB,Fayetteville Fleet Management
+QMDZ2FOC,Cocoa Beach Fleet Management C
+QMDZ2FOD,Fort Walton Beach Fleet Manage
+QMDZ2FOE,Louisville Fleet Management Ce
+QMDZ2FOF,Milwaukee Fleet Management Cen
+QMDZ2FOG,Chicago Fleet Management Cente
+QMDZ2FOH,Dayton Fleet Management Center
+QMDZ2FS,Branch A
+QMDZ2FSA,Section 1
+QMDZ2FSS,Section 2
+QMDZ3,Zone 3
+QMDZ3FO,Branch B
+QMDZ3FOA,Kansas City Fleet Management C
+QMDZ3FOB,St. Louis Fleet Management Cen
+QMDZ3FOC,Fort Worth Fleet Management Ce
+QMDZ3FOD,Oklahoma City Fleet Management
+QMDZ3FOE,San Antonio Fleet Management C
+QMDZ3FOF,El Paso Fleet Management Cente
+QMDZ3FOG,Denver Fleet Management Center
+QMDZ3FOH,Bismark Fleet Management Cente
+QMDZ3FOI,Salt Lake City Fleet Managemen
+QMDZ3FOJ,Gallup Fleet Management Center
+QMDZ3FS,Branch A
+QMDZ3FSA,Section 1
+QMDZ3FSS,Section 2
+QMDZ4,Zone 4
+QMDZ4FC,Branch C
+QMDZ4FCA,Auburn Fleet Management Center
+QMDZ4FCB,Honolulu Fleet Management Cent
+QMDZ4FCC,Anchorage Fleet Management Cen
+QMDZ4FO,Branch B
+QMDZ4FOA,San Francisco Fleet Mgmt Cente
+QMDZ4FOB,San Diego Fleet Mgmt Center
+QMDZ4FOD,Phoenix Fleet Mgmt Center
+QMDZ4FOF,Vancouver Fleet Mgmt Center
+QMDZ4FOI,Los Angeles Fleet Management C
+QMDZ4FS,Branch A
+QMDZ4FSA,Section 1
+QMDZ4FSS,Section 2
+QMDZA,Management and Program Support
+QMDZAA,Program Support Center
+QME,Emergency Management Program O
+QP,FAS/Office of Enterprise Strat
+QP0F,MAS Program Management Office
+QP0G,Workforce Transformation Divis
+QP0GA,Branch A
+QP0GB,Branch B
+QP1,Ofc of the Deputy Asst Commiss
+QP1A,Management & Program Support D
+QP1B,Stakeholder Engagement Divisio
+QP1C,Strategy Execution Division
+QP1D,Strategic Plan & Perf Mgmt Div
+QP1DA,Branch A
+QP1DB,Branch B
+QP1E,Gov-wide PMO for Category Mgmt
+QP1EA,Branch A
+QP1EB,Branch B
+QP1F,Digital Innovation Division
+QQ,Office of Solutions
+QQ1,Cloud.gov
+QQ2,Login.gov
+QQ2A,Branch A
+QQ2B,Branch B
+QQ2C,Branch C
+QQ2D,Branch D
+QQ2E,Branch E
+QQ2F,Branch F
+QQ2G,Branch G
+QQ3,IT Portfolio
+QQA,Data & Analytics
+QQB,Public Experience
+QQBA,Content & Outreach
+QQBB,Customer Experience
+QQBC,Delivery & Channel Ops
+QQBD,Branch D
+QQBE,Branch E
+QQC,Secure Cloud
+QQCA,Branch A
+QQCB,Branch B
+QQD,Smarter IT
+QQE,Innovation
+QQF,Business Management/10X
+QQG,MAX.gov & Identity
+QQGA,Branch A
+QQGB,Branch B
+QQH,Artificial Intelligence
+QQHA,ARP
+QQHB,USDC
+QQHC,Branch C
+QR,FAS/Ofc of Prof Srv & Human Ca
+QRA,Office of Contracting Operatio
+QRAA,Contracting Division A
+QRAAA,Branch A
+QRAAB,Branch B
+QRAAC,Branch C
+QRAAE,Branch E
+QRAB,Contracting Division B
+QRABA,Branch A
+QRABC,Branch C
+QRABD,Branch D
+QRAC,Contracting Division C
+QRACC,Branch C
+QRACD,Branch D
+QRACE,Branch E
+QRAD,Contracting Division D
+QRADA,Branch A
+QRADB,Branch B
+QRADC,Branch C
+QRBA,Professional Services Program
+QRBB,Gov-wide Strtgc Init. & Bus. I
+QRBD,Center for Charge Card Managem
+QRBDA,Branch A
+QRBDB,Branch B
+QRBE,AAS Program Management Divisio
+QRBF,Customer Account Management Di
+QRBG,Community Outreach & Engagemen
+QRC,Office of Business Operations
+QRCA,Program Accountability Divisio
+QRCB,Supplier Accountability Divisi
+QRCBA,Branch A
+QRCBB,Branch B
+QRCC,Mgmt Support & Workforce Dev D
+QS,FAS/Ofc of Gen Sup & Svcs Cate
+QS0D,Mgmt and Program Support Divis
+QS0E,Portfolio Outreach Division
+QS0F,Business Operations Support Di
+QS0FAA,Section 1
+QS0FAB,Section 2
+QS0FB,Branch B
+QS0FBA,Section 1
+QS0FBB,Section 2
+QS1,Ofc of Dep Asst Commissioner
+QSA,Office of Acquisition Manageme
+QSAB,GSS Central Office Acquisition
+QSABA,Branch A
+QSABB,Branch B
+QSAC,Supply Chain & Acq. Support Di
+QSC,Office of Personal Property Ma
+QSCA,Utilization & Donation Program
+QSCB,Sales Program Division
+QSD,Office of Supply Chain Mgmt (S
+QSD1,Ofc of Supply Chain Mgmt - Depu
+QSDP,Policy Plans & Prog Integ Div
+QSDPA,Branch A
+QSDPB,Branch B
+QSDQ,Supply Operations Division
+QSDQD,Branch A
+QSDQE,Branch B
+QSR,Office of Retail Operations
+QSRA,Operations Division
+QSRAA,Branch A
+QSRAB,Branch B
+QSRB,Strategic Integration Division
+QT,FAS/Ofc of IT Category
+QT1,Deputy AC Ofc of IT Category
+QT1A,Mgmt Support & Workforce Dev D
+QT1AA,Branch A
+QT1AB,Branch B
+QT1B,Technology Governance & Mgmt D
+QT1C,Accountability & Opr'l Analysi
+QT1E,Enterprise Strategy & Intel Di
+QT1EA,Branch A
+QT1EB,Branch B
+QT1F,Enterprise Outreach Division
+QT1G,IT Vendor Management Office
+QT2,Deputy AC Acquisition
+QT2B,Business Operations Division
+QT2BA,Branch A
+QT2BB,Branch B
+QT2C,Supply Chain Risk Management D
+QT2CA,Branch A
+QT2CB,Branch B
+QT2F,Office of Acquisition Operatio
+QT2F1,Ofc of Acq Ops - Deputy of IT S
+QT2F1A,Contract Division 1
+QT2F1AA,Branch A
+QT2F1AB,Branch B
+QT2F1AC,Branch C
+QT2F1AD,Branch D
+QT2F1B,Contract Division 2
+QT2F1BA,Branch A
+QT2F1BB,Branch B
+QT2F1C,Contract Division 3
+QT2F1CA,Branch A
+QT2F1CB,Branch B
+QT2F1CC,Branch C
+QT2F1D,Contract Division 4
+QT2F1DA,Branch A
+QT2F1DB,Branch B
+QT2F1E,Contract Division 5
+QT2F1EA,Branch A
+QT2F1EB,Branch B
+QT2F2,Ofc of Acq Ops - Dep Interagenc
+QT2F2A,Services Contracting Division
+QT2F2AA,Branch A
+QT2F2AB,Branch B
+QT2F2B,Services Contracting Division
+QT2F2BA,Branch A
+QT2F2BB,Branch B
+QT2F2C,Services Contracting Division
+QT2F2CA,Branch A
+QT2F2CB,Branch B
+QT2F2D,Services Contracting Division
+QT2F2DA,Branch A
+QT2F2DB,Branch B
+QT2F2DC,Branch C
+QT2F2E,Services Contracting Division
+QT2FA,Governance Division
+QT2FAA,Branch A
+QT2FAB,Branch B
+QT3,Deputy AC Category Mgmt
+QT3A,IT Security Division
+QT3A1,Deputy - IT Security Division
+QT3A1A,Branch A
+QT3A1B,Branch B
+QT3AA,Branch A
+QT3AB,Branch B
+QT3B,Identity Credential & Access M
+QT3BA,Branch A
+QT3BB,Branch B
+QT3BC,Branch C
+QT3C1,Deputy - Ofc of Enterprise Tech
+QT3CI,Program Management Division
+QT3CIA,Branch A
+QT3CIB,Branch B
+QT3CJ,Business Management Division
+QT3CJA,Branch A
+QT3CJAA,Section 1
+QT3CJAB,Section 2
+QT3CJAC,Section 3
+QT3CJAD,Section 4
+QT3CJB,Branch B
+QT3CJC,Branch C
+QT3CK,Technical Account Management D
+QT3CKA,Branch A
+QT3CKAA,Section 1
+QT3CKAB,Section 2
+QT3CKAC,Section 3
+QT3CKB,Branch B
+QT3CKBA,Section 1
+QT3CKBB,Section 2
+QT3CKC,Branch C
+QT3CL,Operations & System Management
+QT3CLA,Branch A
+QT3CLAA,Section 1
+QT3CLAB,Section 2
+QT3CLAC,Section 3
+QT3CLAD,Section 4
+QT3CLB,Branch B
+QT3CLBA,Section 1
+QT3CLBB,Section 2
+QT3CLC,Branch C
+QT3G1,Deputy - Office of IT Services
+QT3GA,Business and Operations Divisi
+QT3GAA,Branch A
+QT3GAB,Branch B
+QT3GD,Program Support Division
+QT3GDA,Branch A
+QT3GDB,Branch B
+QT3GE,Solutions Development Division
+QT3J,Office of Category Mgmt
+QT3JA,Category Mission Support Divis
+QT3JC,Customer Strategic Solutions D
+QT3JCA,Branch A
+QT3JCB,Branch B
+QT3JCC,Branch C
+QT3JD,Strategic Programs Division
+QT3JDA,Branch A
+QT3JDB,Branch B
+QT3K,Office of IT Products
+QT3KA,Software Div
+QT3KAA,Branch A
+QT3KAB,Branch B
+QT3KB,Hardware Div
+QU,Office of Clients & Markets
+QUA,Presidential Innovation Fellows
 QUAA,Branch A
 QUAB,Branch B
 QUAC,Branch C
+QUB,Centers of Excellence
 QUBA,Data & Analytics
 QUBB,Customer Experience & Contact Center
 QUBC,Cloud Adoption & Infrastructure
@@ -46,14 +448,11 @@ QUBD,Acquisition
 QUBE,Client Services
 QUBF,Center F
 QUBG,Center G
+QUC,Outreach
+QUD,Client Development
+QUE,18F
 QUEA,18F Chapters
-QUEB,18F Portfolios
 QUEAA,Engineering
-QUEAB,Product
-QUEAC,Design
-QUEAD,Strategy
-QUEAE,Acquisition
-QUEAF,Account Management
 QUEAAA,The Cohort Formerly Known as Space Goats
 QUEAAB,Ephemere Cohort
 QUEAAC,Bellatrix Cohort
@@ -61,22 +460,46 @@ QUEAAD,Chumanjalaal Cohort
 QUEAAE,Unnamed Cohort E
 QUEAAF,Unnamed Cohort F
 QUEAAG,Unnamed Cohort G
+QUEAAH,Unnamed Cohort H
+QUEAAI,Unnamed Cohort I
+QUEAB,Product
+QUEABA,Branch A
+QUEABB,Branch B
+QUEABC,Branch C
+QUEAC,Design
 QUEACA,Product Design
 QUEACB,Content Strategy
 QUEACC,User Experience
 QUEACD,Change Strategy
-QUEABA,Branch A
-QUEABB,Branch B
-QUEABC,Branch C
+QUEACE,Unit 5
+QUEACG,Unit 7
+QUEACH,Unit 8
+QUEAD,Strategy
+QUEAE,Acquisition
+QUEAF,Account Management
+QUEB,18F Portfolios
 QUEBA,National Security & Intelligence
 QUEBB,Public Benefits
 QUEBC,Account Management
-QUEBD,Justice & Courts
-QUEBE,Section 5
-QUEBF,Section 6
 QUEBCA,Unit 1
 QUEBCB,Unit 2
 QUEBCC,Unit 3
 QUEBCD,Unit 4
 QUEBCE,Unit 5
 QUEBCF,Unit 6
+QUEBD,Justice & Courts
+QUEBE,Section 5
+QUEBF,Section 6
+QV,FAS/Ofc of Policy and Compliance
+QVA,Acquisition Workforce Division
+QVB,Acquisition Policy Division
+QVBA,Branch A
+QVBB,Branch B
+QVC,Acquisition Management Division
+QVCA,Branch A
+QVCB,Branch B
+QVD,Acquisition Evidence & Analysis
+QVDA,Branch A
+QVDB,Branch B
+QVE,Management and Oversight Division
+QVF,Office of Supply Chain Risk Management

--- a/src/scripts/q-expand.test.js
+++ b/src/scripts/q-expand.test.js
@@ -1,3 +1,5 @@
+const fs = require("fs");
+
 const { getApp } = require("../utils/test");
 const script = require("./q-expand");
 
@@ -142,5 +144,15 @@ describe("q-expand csv data", () => {
     expect(csvData.QUBE).toBe("Client Services");
     expect(csvData.QUEAF).toBe("Account Management");
     expect(csvData.QUEAAC).toBe("Bellatrix Cohort");
+  });
+
+  it("is formatted correctly", () => {
+    const csv = fs
+      .readFileSync("config/q-expand.csv", { encoding: "utf-8" })
+      .trim()
+      .split("\n");
+    const lines = csv.map((line) => line.split(","));
+    const invalid = lines.filter((parts) => parts.length !== 2);
+    expect(invalid.length).toBe(0);
   });
 });


### PR DESCRIPTION
This PR adds 400+ more titles to the Q-Expander bot.

This PR makes it look like a few old titles were removed. They weren't sorted, so this also sorts those so they're easier to find.

Also some titles may be cut off. This is because the spreadsheet has some titles cut off due to length. I just haven't found all of them yet and some of them I don't know what the rest of the word is. Figured adding partially complete titles was better than leaving them off.