### PR TITLE
Stop dev instances during nightly restage

### DIFF
--- a/.github/workflows/nightly_restage.yml
+++ b/.github/workflows/nightly_restage.yml
@@ -18,6 +18,11 @@ jobs:
           CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
           CF_SPACE: ${{ secrets.CF_SPACE }}
           CF_USERNAME: ${{ secrets.CF_USERNAME }}
+
+        # Log into prod, restage Charlie, then switch to dev and stop that
+        # instance, if it's running
         run: |
           cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
           cf restage $CF_APP
+          cf target -s $CF_SPACE_DEV
+          cf stop $CF_APP


### PR DESCRIPTION
Charlie's `dev` instance should be stopped when nobody is actively using it, to save on cost. This PR updates the nightly restage automation so that it also stops the `dev` instance as well, so if we forget - which we will - it'll automatically stop itself overnight.