### PR TITLE
Make the coffeemate regex more permissive

### DIFF
--- a/src/scripts/coffeemate.js
+++ b/src/scripts/coffeemate.js
@@ -11,7 +11,7 @@ const baseResponse = {
 };
 
 module.exports = (app) => {
-  app.message(/coffee me(\s+|$)/i, async (message) => {
+  app.message(/\bcoffee me\b/i, async (message) => {
     const {
       context: {
         matches: [, scopeMatch],

--- a/src/scripts/coffeemate.test.js
+++ b/src/scripts/coffeemate.test.js
@@ -18,7 +18,7 @@ describe("coffeemate", () => {
     coffeemate(app);
 
     expect(app.message).toHaveBeenCalledWith(
-      /coffee me(\s+|$)/i,
+      /\bcoffee me\b/i,
       expect.any(Function)
     );
   });


### PR DESCRIPTION
Currently the regex requires that the text `coffee me` be followed by whitespace or the end of the line, which means it does not match `coffee me, please` or `coffee me.` with punctuation. This PR changes the requirement so that `coffee mate` is followed by a word boundary, and also preceded by one, to make it easier to trigger the bot without making it more likely to do so accidentally.