### PR TITLE
Add some of Charlie's interactive functionality to its homepage

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,9 +1,0 @@
-[
-  "hubot-ascii-art",
-  "hubot-help",
-  "hubot-pugme",
-  "hubot-redis-brain",
-  "hubot-scripts-us-federal-holidays",
-  "hubot-scripts-us-federal-holidays-reminder",
-  "hubot-xkcd"
-]

--- a/src/scripts/coffeemate.js
+++ b/src/scripts/coffeemate.js
@@ -1,8 +1,12 @@
 const {
+  homepage,
   slack: { addEmojiReaction, postEphemeralResponse, sendDirectMessage },
 } = require("../utils");
 
 const brainKey = "coffeemate_queue";
+
+const COFFEE_ACTION_ID = "coffee_me";
+const UNCOFFEE_ACTION_ID = "un_coffee_me";
 
 const baseResponse = {
   icon_emoji: ":coffee:",
@@ -11,6 +15,139 @@ const baseResponse = {
 };
 
 module.exports = (app) => {
+  const addToCoffeeQueue = async (userId, message = false, scope = "") => {
+    const key = `${brainKey}${scope}`;
+    const queue = app.brain.get(key) || [];
+
+    if (queue.includes(userId)) {
+      // If the request to be added to the queue came from a Slack message,
+      // let the user know they're already in the queue. This request can also
+      // come from a homepage interaction, in which case we already display that
+      // they're in the queue.
+      if (message) {
+        await postEphemeralResponse(message, {
+          ...baseResponse,
+          text: `You’re already in the${
+            scope ? ` ${scope}` : ""
+          } queue. As soon as we find someone else to meet with, we’ll introduce you!`,
+        });
+      }
+      return;
+    }
+
+    queue.push(userId);
+    app.brain.set(key, queue);
+
+    // Now do we have a pair or not?
+    if (queue.length < 2) {
+      if (message) {
+        await postEphemeralResponse(message, {
+          ...baseResponse,
+          text: `You’re in line for${
+            scope ? ` ${scope}` : ""
+          } coffee! You’ll be introduced to the next person who wants to meet up.`,
+        });
+      }
+    } else {
+      try {
+        // pair them up
+        if (message) {
+          await postEphemeralResponse(message, {
+            ...baseResponse,
+            text: `You’ve been matched up for coffee with <@${queue[0]}>! `,
+          });
+        }
+
+        // Now start a 1:1 DM chat between the people in queue.
+        await sendDirectMessage([...queue], baseResponse);
+      } catch (e) {
+        // We don't really have a good way of capturing errors. The log is noisy
+        // so just writing there isn't necessarily helpful, but we'll go ahead
+        // and do it.
+        app.logger.error(e);
+      } finally {
+        // And always empty the queue, no matter what; otherwise, users could
+        // get stuck and we'd have to go manually edit the database to fix it.
+        queue.length = 0;
+        app.brain.set(key, queue);
+      }
+    }
+  };
+
+  homepage.registerInteractive((userId) => {
+    const inQueue = app.brain.get(brainKey)?.includes(userId);
+
+    if (inQueue) {
+      return {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `:coffee: You’re in the coffee queue! As soon as we find someone else to meet with, we’ll introduce you.`,
+        },
+        accessory: {
+          type: "button",
+          text: { type: "plain_text", text: "Leave queue" },
+          action_id: UNCOFFEE_ACTION_ID,
+        },
+      };
+    }
+
+    return {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ":coffee: Sign up for a virtual coffee",
+      },
+      accessory: {
+        type: "button",
+        text: { type: "plain_text", text: "Coffee Me!" },
+        action_id: COFFEE_ACTION_ID,
+      },
+    };
+  });
+
+  app.action(
+    UNCOFFEE_ACTION_ID,
+    async ({
+      ack,
+      body: {
+        user: { id: userId },
+      },
+      client,
+    }) => {
+      await ack();
+
+      const queue = app.brain.get(brainKey) || [];
+      const index = queue.findIndex((id) => id === userId);
+
+      if (index >= 0) {
+        queue.splice(index, 1);
+        app.brain.set(brainKey, queue);
+
+        // Now that the user's queue status has changed, update the homepage.
+        homepage.refresh(userId, client);
+      }
+    }
+  );
+
+  app.action(
+    COFFEE_ACTION_ID,
+    async ({
+      ack,
+      body: {
+        user: { id: userId },
+      },
+      client,
+    }) => {
+      await ack();
+
+      await addToCoffeeQueue(userId);
+
+      // The user's queue status may have changed; update the homepage in case.
+      homepage.refresh(userId, client);
+    }
+  );
+
   app.message(/\bcoffee me\b/i, async (message) => {
     const {
       context: {
@@ -31,56 +168,12 @@ module.exports = (app) => {
       return out === "please" ? "" : out;
     })();
 
-    const key = `${brainKey}${scope}`;
-    const queue = app.brain.get(key) || [];
-
     await addEmojiReaction(message, "coffee");
 
-    // First, is the current user in already in the queue?
-    // If so, just let them know
-    if (queue.includes(user)) {
-      await postEphemeralResponse(message, {
-        ...baseResponse,
-        text: `You’re already in the${
-          scope ? ` ${scope}` : ""
-        } queue. As soon as we find someone else to meet with, we’ll introduce you!`,
-      });
-      return;
-    }
-
-    // If we didn't bail out already, add the current user to the queue
-    queue.push(user);
-    app.brain.set(key, queue);
-
-    // Now do we have a pair or not?
-    if (queue.length < 2) {
-      await postEphemeralResponse(message, {
-        ...baseResponse,
-        text: `You’re in line for${
-          scope ? ` ${scope}` : ""
-        } coffee! You’ll be introduced to the next person who wants to meet up.`,
-      });
-    } else {
-      try {
-        // pair them up
-        await postEphemeralResponse(message, {
-          ...baseResponse,
-          text: `You’ve been matched up for coffee with <@${queue[0]}>! `,
-        });
-
-        // Now start a 1:1 DM chat between the people in queue.
-        await sendDirectMessage([...queue], baseResponse);
-      } catch (e) {
-        // We don't really have a good way of capturing errors. The log is noisy
-        // so just writing there isn't necessarily helpful, but we'll go ahead
-        // and do it.
-        app.logger.error(e);
-      } finally {
-        // And always empty the queue, no matter what; otherwise, users could
-        // get stuck and we'd have to go manually edit the database to fix it.
-        queue.length = 0;
-        app.brain.set(key, queue);
-      }
-    }
+    await addToCoffeeQueue(user, message, scope);
   });
 };
+
+module.exports.COFFEE_ACTION_ID = COFFEE_ACTION_ID;
+module.exports.UNCOFFEE_ACTION_ID = UNCOFFEE_ACTION_ID;
+module.exports.BRAIN_KEY = brainKey;

--- a/src/scripts/erg-inviter.js
+++ b/src/scripts/erg-inviter.js
@@ -59,7 +59,7 @@ module.exports = async (app) => {
         view: {
           type: "modal",
           title: { type: "plain_text", text: "TTS affinity groups" },
-          blocks: [...getButtons()],
+          blocks: getButtons(),
         },
       });
     }

--- a/src/scripts/erg-inviter.js
+++ b/src/scripts/erg-inviter.js
@@ -7,7 +7,7 @@ const {
   slack: { postMessage, sendDirectMessage },
 } = require("../utils");
 
-const requestionInvitationActionId = "erg_invite_request";
+const requestERGInvitationActionId = "erg_invite_request";
 const showGroupsModalActionId = "show_erg_modal";
 
 const getERGs = () => {
@@ -32,7 +32,7 @@ module.exports = async (app) => {
         type: "button",
         text: { type: "plain_text", text: `Request invitation to ${name}` },
         value: channel,
-        action_id: requestionInvitationActionId,
+        action_id: requestERGInvitationActionId,
       },
     }));
 
@@ -66,7 +66,7 @@ module.exports = async (app) => {
   );
 
   app.action(
-    requestionInvitationActionId,
+    requestERGInvitationActionId,
     async ({
       action: { value: channel },
       ack,
@@ -110,6 +110,6 @@ module.exports = async (app) => {
   });
 };
 
-module.exports.requestionInvitationActionId = requestionInvitationActionId;
-module.exports.showGroupsModalActionId = showGroupsModalActionId;
+module.exports.REQUEST_ERG_INVITATION_ACTION_ID = requestERGInvitationActionId;
+module.exports.SHOW_ERG_MODAL_ACTION_ID = showGroupsModalActionId;
 module.exports.getERGs = getERGs;

--- a/src/scripts/erg-inviter.test.js
+++ b/src/scripts/erg-inviter.test.js
@@ -37,14 +37,16 @@ describe("ERG inviter", () => {
       bot(app);
 
       expect(app.action).toHaveBeenCalledWith(
-        bot.requestionInvitationActionId,
+        bot.REQUEST_ERG_INVITATION_ACTION_ID,
         expect.any(Function)
       );
     });
 
     it("sends a message to the appropriate channel when a user requests an invitation", async () => {
       bot(app);
-      const handler = app.getActionHandler(bot.requestionInvitationActionId);
+      const handler = app.getActionHandler(
+        bot.REQUEST_ERG_INVITATION_ACTION_ID
+      );
       const ack = jest.fn().mockResolvedValue();
 
       await handler({
@@ -110,7 +112,7 @@ describe("ERG inviter", () => {
               type: "button",
               text: { type: "plain_text", text: "Request invitation to one" },
               value: "one1",
-              action_id: bot.requestionInvitationActionId,
+              action_id: bot.REQUEST_ERG_INVITATION_ACTION_ID,
             },
           },
           {
@@ -120,7 +122,7 @@ describe("ERG inviter", () => {
               type: "button",
               text: { type: "plain_text", text: "Request invitation to two" },
               value: "two2",
-              action_id: bot.requestionInvitationActionId,
+              action_id: bot.REQUEST_ERG_INVITATION_ACTION_ID,
             },
           },
           {
@@ -130,7 +132,7 @@ describe("ERG inviter", () => {
               type: "button",
               text: { type: "plain_text", text: "Request invitation to three" },
               value: "three3",
-              action_id: bot.requestionInvitationActionId,
+              action_id: bot.REQUEST_ERG_INVITATION_ACTION_ID,
             },
           },
         ],
@@ -163,7 +165,7 @@ describe("ERG inviter", () => {
         accessory: {
           type: "button",
           text: { type: "plain_text", text: "See a list of groups" },
-          action_id: bot.showGroupsModalActionId,
+          action_id: bot.SHOW_ERG_MODAL_ACTION_ID,
         },
       });
     });
@@ -181,14 +183,14 @@ describe("ERG inviter", () => {
     it("registers the action", () => {
       bot(app);
       expect(app.action).toHaveBeenCalledWith(
-        bot.showGroupsModalActionId,
+        bot.SHOW_ERG_MODAL_ACTION_ID,
         expect.any(Function)
       );
     });
 
     it("shows a modal when the action is fired", async () => {
       bot(app);
-      const action = app.getActionHandler(bot.showGroupsModalActionId);
+      const action = app.getActionHandler(bot.SHOW_ERG_MODAL_ACTION_ID);
 
       const message = {
         ack: jest.fn(),
@@ -215,7 +217,7 @@ describe("ERG inviter", () => {
                 type: "button",
                 text: { type: "plain_text", text: "Request invitation to one" },
                 value: "one1",
-                action_id: bot.requestionInvitationActionId,
+                action_id: bot.REQUEST_ERG_INVITATION_ACTION_ID,
               },
             },
             {
@@ -225,7 +227,7 @@ describe("ERG inviter", () => {
                 type: "button",
                 text: { type: "plain_text", text: "Request invitation to two" },
                 value: "two2",
-                action_id: bot.requestionInvitationActionId,
+                action_id: bot.REQUEST_ERG_INVITATION_ACTION_ID,
               },
             },
             {
@@ -238,7 +240,7 @@ describe("ERG inviter", () => {
                   text: "Request invitation to three",
                 },
                 value: "three3",
-                action_id: bot.requestionInvitationActionId,
+                action_id: bot.REQUEST_ERG_INVITATION_ACTION_ID,
               },
             },
           ],

--- a/src/scripts/erg-inviter.test.js
+++ b/src/scripts/erg-inviter.test.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const {
   getApp,
   utils: {
+    homepage,
     slack: { postMessage, sendDirectMessage },
   },
 } = require("../utils/test");
@@ -36,14 +37,14 @@ describe("ERG inviter", () => {
       bot(app);
 
       expect(app.action).toHaveBeenCalledWith(
-        bot.actionId,
+        bot.requestionInvitationActionId,
         expect.any(Function)
       );
     });
 
     it("sends a message to the appropriate channel when a user requests an invitation", async () => {
       bot(app);
-      const handler = app.getActionHandler();
+      const handler = app.getActionHandler(bot.requestionInvitationActionId);
       const ack = jest.fn().mockResolvedValue();
 
       await handler({
@@ -107,9 +108,9 @@ describe("ERG inviter", () => {
             text: { type: "mrkdwn", text: `• *one*: Number One` },
             accessory: {
               type: "button",
-              text: { type: "plain_text", text: "Request invitation" },
+              text: { type: "plain_text", text: "Request invitation to one" },
               value: "one1",
-              action_id: bot.actionId,
+              action_id: bot.requestionInvitationActionId,
             },
           },
           {
@@ -117,9 +118,9 @@ describe("ERG inviter", () => {
             text: { type: "mrkdwn", text: `• *two*: Number Two` },
             accessory: {
               type: "button",
-              text: { type: "plain_text", text: "Request invitation" },
+              text: { type: "plain_text", text: "Request invitation to two" },
               value: "two2",
-              action_id: bot.actionId,
+              action_id: bot.requestionInvitationActionId,
             },
           },
           {
@@ -127,14 +128,121 @@ describe("ERG inviter", () => {
             text: { type: "mrkdwn", text: `• *three*: Number Three` },
             accessory: {
               type: "button",
-              text: { type: "plain_text", text: "Request invitation" },
+              text: { type: "plain_text", text: "Request invitation to three" },
               value: "three3",
-              action_id: bot.actionId,
+              action_id: bot.requestionInvitationActionId,
             },
           },
         ],
         text: "Here are the available employee afinity group channels.",
         username: "Inclusion Bot",
+      });
+    });
+  });
+
+  describe("sets up a homepage interaction", () => {
+    it("registers a homepage interaction", () => {
+      bot(app);
+
+      expect(homepage.registerInteractive).toHaveBeenCalledWith(
+        expect.any(Function)
+      );
+    });
+
+    it("sends back a UI for the homepage", () => {
+      bot(app);
+      const getUI = homepage.registerInteractive.mock.calls[0][0];
+      const ui = getUI();
+
+      expect(ui).toEqual({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: ":inclusion-bot: Request an invitation to TTS employee affinity group Slack channels:.",
+        },
+        accessory: {
+          type: "button",
+          text: { type: "plain_text", text: "See a list of groups" },
+          action_id: bot.showGroupsModalActionId,
+        },
+      });
+    });
+  });
+
+  describe("handles the action for showing a modal of ERG options", () => {
+    beforeEach(() => {
+      bot.getERGs = () => ({
+        one: { description: "Number One", channel: "one1" },
+        two: { description: "Number Two", channel: "two2" },
+        three: { description: "Number Three", channel: "three3" },
+      });
+    });
+
+    it("registers the action", () => {
+      bot(app);
+      expect(app.action).toHaveBeenCalledWith(
+        bot.showGroupsModalActionId,
+        expect.any(Function)
+      );
+    });
+
+    it("shows a modal when the action is fired", async () => {
+      bot(app);
+      const action = app.getActionHandler(bot.showGroupsModalActionId);
+
+      const message = {
+        ack: jest.fn(),
+        body: { trigger_id: "trigger id" },
+        client: { views: { open: jest.fn() } },
+      };
+
+      await action(message);
+
+      expect(message.ack).toHaveBeenCalled();
+      expect(message.client.views.open).toHaveBeenCalledWith({
+        trigger_id: "trigger id",
+        view: {
+          type: "modal",
+          title: {
+            type: "plain_text",
+            text: "TTS affinity groups",
+          },
+          blocks: [
+            {
+              type: "section",
+              text: { type: "mrkdwn", text: `• *one*: Number One` },
+              accessory: {
+                type: "button",
+                text: { type: "plain_text", text: "Request invitation to one" },
+                value: "one1",
+                action_id: bot.requestionInvitationActionId,
+              },
+            },
+            {
+              type: "section",
+              text: { type: "mrkdwn", text: `• *two*: Number Two` },
+              accessory: {
+                type: "button",
+                text: { type: "plain_text", text: "Request invitation to two" },
+                value: "two2",
+                action_id: bot.requestionInvitationActionId,
+              },
+            },
+            {
+              type: "section",
+              text: { type: "mrkdwn", text: `• *three*: Number Three` },
+              accessory: {
+                type: "button",
+                text: {
+                  type: "plain_text",
+                  text: "Request invitation to three",
+                },
+                value: "three3",
+                action_id: bot.requestionInvitationActionId,
+              },
+            },
+          ],
+        },
       });
     });
   });

--- a/src/scripts/federal-holidays.js
+++ b/src/scripts/federal-holidays.js
@@ -3,28 +3,39 @@ const moment = require("moment");
 const {
   dates: { getNextHoliday },
   holidays: { emojis },
+  homepage: { registerDidYouKnow },
 } = require("../utils");
 
+const getHolidayText = () => {
+  const holiday = getNextHoliday();
+  const nextOne = moment(holiday.date);
+  const daysUntil = Math.ceil(
+    moment.duration(nextOne.utc().format("x") - Date.now()).asDays()
+  );
+
+  const emoji = emojis.get(holiday.name);
+
+  return `The next federal holiday is ${
+    holiday.alsoObservedAs ?? holiday.name
+  } ${emoji || ""}${emoji ? " " : ""}in ${daysUntil} days on ${nextOne
+    .utc()
+    .format("dddd, MMMM Do")}`;
+};
+
 module.exports = (app) => {
+  registerDidYouKnow(() => ({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: getHolidayText(),
+    },
+  }));
+
   app.message(
     directMention(),
     /(when is( the)? )?next (federal )?holiday/i,
     ({ say }) => {
-      const holiday = getNextHoliday();
-      const nextOne = moment(holiday.date);
-      const daysUntil = Math.ceil(
-        moment.duration(nextOne.utc().format("x") - Date.now()).asDays()
-      );
-
-      const emoji = emojis.get(holiday.name);
-
-      say(
-        `The next federal holiday is ${
-          holiday.alsoObservedAs ?? holiday.name
-        } ${emoji || ""}${emoji ? " " : ""}in ${daysUntil} days on ${nextOne
-          .utc()
-          .format("dddd, MMMM Do")}`
-      );
+      say(getHolidayText());
     }
   );
 };

--- a/src/scripts/federal-holidays.test.js
+++ b/src/scripts/federal-holidays.test.js
@@ -4,6 +4,7 @@ const bot = require("./federal-holidays");
 const {
   utils: {
     dates: { getNextHoliday },
+    homepage: { registerDidYouKnow },
   },
 } = require("../utils/test");
 
@@ -31,6 +32,31 @@ describe("federal holidays bot", () => {
       /(when is( the)? )?next (federal )?holiday/i,
       expect.any(Function)
     );
+  });
+
+  it("registers did-you-know content for Charlie's homepage", () => {
+    bot(app);
+
+    expect(registerDidYouKnow).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it("sends did-you-know content when requested", () => {
+    bot(app);
+
+    getNextHoliday.mockReturnValue({
+      date: moment.tz("1970-01-02T00:00:00", "UTC"),
+      name: "Test Holiday day",
+    });
+
+    const content = registerDidYouKnow.mock.calls[0][0]();
+
+    expect(content).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "The next federal holiday is Test Holiday day in 1 days on Friday, January 2nd",
+      },
+    });
   });
 
   describe("responds to a request for the next federal holiday", () => {

--- a/src/scripts/home.js
+++ b/src/scripts/home.js
@@ -39,7 +39,7 @@ module.exports = async (app) => {
               text: "Did you know?",
             },
           },
-          ...getDidYouKnow(userId).flat(),
+          ...getDidYouKnow(userId),
           { type: "divider" },
           {
             type: "header",
@@ -48,7 +48,7 @@ module.exports = async (app) => {
               text: "Interactions",
             },
           },
-          ...getInteractive(userId).flat(),
+          ...getInteractive(userId),
           { type: "divider" },
           {
             type: "header",

--- a/src/scripts/home.test.js
+++ b/src/scripts/home.test.js
@@ -1,8 +1,11 @@
 const moment = require("moment");
 
 const {
-  optOut: { BRAIN_KEY },
-} = require("../utils");
+  utils: {
+    homepage: { getDidYouKnow, getInteractive },
+    optOut: { BRAIN_KEY },
+  },
+} = require("../utils/test");
 
 const {
   getApp,
@@ -153,6 +156,9 @@ describe("Charlie's home app", () => {
       await home;
       const event = app.getEventHandler();
 
+      getDidYouKnow.mockReturnValue(["first", "second"]);
+      getInteractive.mockReturnValue(["aaa", "bbb"]);
+
       const date = moment("1998-01-09");
 
       // Set the current time to one day before the holiday
@@ -181,6 +187,9 @@ describe("Charlie's home app", () => {
 
       event(message);
 
+      expect(getDidYouKnow).toHaveBeenCalledWith("user 1");
+      expect(getInteractive).toHaveBeenCalledWith("user 1");
+
       expect(publish).toHaveBeenCalledWith({
         user_id: "user 1",
         view: {
@@ -190,13 +199,16 @@ describe("Charlie's home app", () => {
               type: "header",
               text: { type: "plain_text", text: expect.any(String) },
             },
+            "first",
+            "second",
+            { type: "divider" },
             {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: "It's *1 days* until the next federal holiday, which is *Wayne Gretzky Day* on Friday, January 9th.",
-              },
+              type: "header",
+              text: { type: "plain_text", text: expect.any(String) },
             },
+            "aaa",
+            "bbb",
+            { type: "divider" },
             {
               type: "header",
               text: {
@@ -293,6 +305,9 @@ describe("Charlie's home app", () => {
       await home;
       const event = app.getEventHandler();
 
+      getDidYouKnow.mockReturnValue(["third", "fifth"]);
+      getInteractive.mockReturnValue(["ccc", "ddd"]);
+
       const date = moment("1998-01-09");
 
       // Set the current time to one day before the holiday
@@ -321,6 +336,9 @@ describe("Charlie's home app", () => {
 
       event(message);
 
+      expect(getDidYouKnow).toHaveBeenCalledWith("user 1");
+      expect(getInteractive).toHaveBeenCalledWith("user 1");
+
       expect(publish).toHaveBeenCalledWith({
         user_id: "user 1",
         view: {
@@ -330,13 +348,16 @@ describe("Charlie's home app", () => {
               type: "header",
               text: { type: "plain_text", text: expect.any(String) },
             },
+            "third",
+            "fifth",
+            { type: "divider" },
             {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: "It's *1 days* until the next federal holiday, which is *Wayne Gretzky Day* on Friday, January 9th.",
-              },
+              type: "header",
+              text: { type: "plain_text", text: expect.any(String) },
             },
+            "ccc",
+            "ddd",
+            { type: "divider" },
             {
               type: "header",
               text: {

--- a/src/utils/homepage.js
+++ b/src/utils/homepage.js
@@ -5,11 +5,11 @@ let refresh = async () => {};
 
 module.exports = {
   getDidYouKnow(userId) {
-    return didYouKnow.map((cb) => cb(userId));
+    return didYouKnow.flatMap((cb) => cb(userId));
   },
 
   getInteractive(userId) {
-    return interactive.map((cb) => cb(userId));
+    return interactive.flatMap((cb) => cb(userId));
   },
 
   refresh: (userId, client) => refresh(userId, client),

--- a/src/utils/homepage.js
+++ b/src/utils/homepage.js
@@ -1,0 +1,28 @@
+const didYouKnow = [];
+const interactive = [];
+
+let refresh = async () => {};
+
+module.exports = {
+  getDidYouKnow(userId) {
+    return didYouKnow.map((cb) => cb(userId));
+  },
+
+  getInteractive(userId) {
+    return interactive.map((cb) => cb(userId));
+  },
+
+  refresh: (userId, client) => refresh(userId, client),
+
+  registerDidYouKnow(callback) {
+    didYouKnow.push(callback);
+  },
+
+  registerInteractive(callback) {
+    interactive.push(callback);
+  },
+
+  registerRefresh(callback) {
+    refresh = callback;
+  },
+};

--- a/src/utils/homepage.test.js
+++ b/src/utils/homepage.test.js
@@ -25,7 +25,7 @@ describe("homepage utility", () => {
       homepage.registerDidYouKnow(fn2);
       homepage.registerDidYouKnow(fn3);
 
-      expect(homepage.getDidYouKnow("user id")).toEqual(["one", 2, ["three"]]);
+      expect(homepage.getDidYouKnow("user id")).toEqual(["one", 2, "three"]);
       expect(fn1).toHaveBeenCalledWith("user id");
       expect(fn2).toHaveBeenCalledWith("user id");
       expect(fn3).toHaveBeenCalledWith("user id");
@@ -50,7 +50,7 @@ describe("homepage utility", () => {
       homepage.registerInteractive(fn2);
       homepage.registerInteractive(fn3);
 
-      expect(homepage.getInteractive("user id")).toEqual(["one", 2, ["three"]]);
+      expect(homepage.getInteractive("user id")).toEqual(["one", 2, "three"]);
       expect(fn1).toHaveBeenCalledWith("user id");
       expect(fn2).toHaveBeenCalledWith("user id");
       expect(fn3).toHaveBeenCalledWith("user id");

--- a/src/utils/homepage.test.js
+++ b/src/utils/homepage.test.js
@@ -1,0 +1,74 @@
+describe("homepage utility", () => {
+  let homepage;
+  beforeEach(() => {
+    // Reset the module before each test so we can be sure we're starting from
+    // a clean state, and anything we register in a test isn't lingering around
+    jest.resetModules();
+    homepage = require("./homepage"); // eslint-disable-line global-require
+  });
+
+  describe("supports the 'did you know section'", () => {
+    it("returns an empty array if nothing is registered", () => {
+      expect(homepage.getDidYouKnow("user id")).toEqual([]);
+    });
+
+    it("returns an array of responses from everything that's registered", () => {
+      const fn1 = jest.fn();
+      const fn2 = jest.fn();
+      const fn3 = jest.fn();
+
+      fn1.mockReturnValue("one");
+      fn2.mockReturnValue(2);
+      fn3.mockReturnValue(["three"]);
+
+      homepage.registerDidYouKnow(fn1);
+      homepage.registerDidYouKnow(fn2);
+      homepage.registerDidYouKnow(fn3);
+
+      expect(homepage.getDidYouKnow("user id")).toEqual(["one", 2, ["three"]]);
+      expect(fn1).toHaveBeenCalledWith("user id");
+      expect(fn2).toHaveBeenCalledWith("user id");
+      expect(fn3).toHaveBeenCalledWith("user id");
+    });
+  });
+
+  describe("supports the interactive section", () => {
+    it("returns an empty array if nothing is registered", () => {
+      expect(homepage.getInteractive("user id")).toEqual([]);
+    });
+
+    it("returns an array of responses from everything that's registered", () => {
+      const fn1 = jest.fn();
+      const fn2 = jest.fn();
+      const fn3 = jest.fn();
+
+      fn1.mockReturnValue("one");
+      fn2.mockReturnValue(2);
+      fn3.mockReturnValue(["three"]);
+
+      homepage.registerInteractive(fn1);
+      homepage.registerInteractive(fn2);
+      homepage.registerInteractive(fn3);
+
+      expect(homepage.getInteractive("user id")).toEqual(["one", 2, ["three"]]);
+      expect(fn1).toHaveBeenCalledWith("user id");
+      expect(fn2).toHaveBeenCalledWith("user id");
+      expect(fn3).toHaveBeenCalledWith("user id");
+    });
+  });
+
+  describe("supports refreshing the homepage", () => {
+    it("does not fail if there is no registered refresher", () => {
+      homepage.refresh();
+    });
+
+    it("calls the registered refresher", () => {
+      const refresher = jest.fn();
+      homepage.registerRefresh(refresher);
+
+      homepage.refresh("user id", "client");
+
+      expect(refresher).toHaveBeenCalledWith("user id", "client");
+    });
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,7 @@
 const { cache } = require("./cache");
 const dates = require("./dates");
 const holidays = require("./holidays");
+const homepage = require("./homepage");
 const optOut = require("./optOut");
 const slack = require("./slack");
 const tock = require("./tock");
@@ -9,6 +10,7 @@ module.exports = {
   cache,
   dates,
   holidays,
+  homepage,
   optOut,
   slack,
   tock,

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -6,6 +6,7 @@ describe("utils / index", () => {
       "cache",
       "dates",
       "holidays",
+      "homepage",
       "optOut",
       "slack",
       "tock",

--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 const brain = require("../brain");
-const { cache, dates, optOut, slack, tock } = require("./index");
+const { cache, dates, homepage, optOut, slack, tock } = require("./index");
 
 // Mock axios and the utility functions, to make it easier for tests to use.
 jest.mock("axios");
@@ -35,6 +35,14 @@ module.exports = {
        *    handlers are registered. Defaults to 0, the first handler.
        */
       getActionHandler: (index = 0) => {
+        if (typeof index === "string") {
+          return action.mock.calls
+            .filter(([actionName]) => actionName === index)
+            .pop()
+            .slice(-1)
+            .pop();
+        }
+
         if (action.mock.calls.length > index) {
           return action.mock.calls[index].slice(-1).pop();
         }
@@ -73,6 +81,7 @@ module.exports = {
   utils: {
     cache,
     dates,
+    homepage,
     optOut,
     slack,
     tock,


### PR DESCRIPTION
This pull request adds coffeemate and the ERG (employee resource/affinity group) inviter to Charlie's homepage.

<img width="578" alt="image" src="https://user-images.githubusercontent.com/1775733/169176320-dc21cd1d-898e-40e6-b953-f072549faa14.png">

---

Into the technical weeds a little bit:

This PR also adds a `homepage` utility that existing scripts can use to register themselves on the homepage. They do this by passing a callback that is called when the homepage is being created. The script can then create [Slack Block Kit](https://api.slack.com/block-kit) objects to define what should be displayed on the homepage. They can return either a single object or an array.

The `home` script will use the `homepage` utility to call all of the scripts that registered themselves and insert their return values into the page that it builds. The `home` script also registers a handler to manually refresh the homepage. Slack will automatically refresh it under some circumstances, but not if (for example) the user clicks a button, in which case it might be desirable to force it to refresh (e.g., if someone signs up for coffeemate).