### PR TITLE
Develop locally without opening public tunnel

### DIFF
--- a/database.local.yml
+++ b/database.local.yml
@@ -1,0 +1,12 @@
+version: "3.2"
+### .env DATABASE_URL ###
+# postgres://charlie-bot:charlie-bot@0.0.0.0:5432/charlie
+services:
+  database:
+    image: postgres:13
+    environment:
+      - POSTGRES_DB=charlie
+      - POSTGRES_PASSWORD=charlie-bot
+      - POSTGRES_USER=charlie-bot
+    ports:
+      - 5432:5432

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "moment-timezone": "^0.5.32",
         "node-schedule": "^2.0.0",
         "pg": "^8.7.1",
-        "plural": "^1.1.0"
+        "plural": "^1.1.0",
+        "qs": "6.10.3"
       },
       "devDependencies": {
         "eslint": "^8.7.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "moment-timezone": "^0.5.32",
     "node-schedule": "^2.0.0",
     "pg": "^8.7.1",
-    "plural": "^1.1.0"
+    "plural": "^1.1.0",
+    "qs": "6.10.3"
   },
   "engines": {
     "node": "^16.10.0"

--- a/src/spoof-message.js
+++ b/src/spoof-message.js
@@ -1,7 +1,8 @@
-require("./env");
-const crypto = require('crypto');
+const crypto = require("crypto");
 const axios = require("axios");
-// const formurlencoded = require('form-urlencoded');
+require("./env");
+const qs = require('qs');
+
 
 // NOTES: bolt's App object requires valid credentials to initialize, so .env must contain valid credentials
 
@@ -17,13 +18,13 @@ function calculateSignature(
   let rawBody;
   if (contentType?.toLocaleLowerCase() === 'application/x-www-form-urlencoded') {
     // Slash commands are sent in this content type
-    rawBody = formurlencoded(body);
+    rawBody = qs.stringify(rawBody,{ format:'RFC1738' })
   } else {
-    var stringBody = JSON.stringify(body);
-    rawBody = stringBody.replace(/\//g, '\\/').replace(/[\u007f-\uffff]/g, (c) => '\\u' + ('0000' + c.charCodeAt(0).toString(16)).slice(-4));
+    const stringBody = JSON.stringify(body);
+    rawBody = stringBody.replace(/\//g, '\\/').replace(/[\u007f-\uffff]/g, (c) => `\\u${  (`0000${  c.charCodeAt(0).toString(16)}`).slice(-4)}`);
   }
   const basestring = ['v0', timestampHeader, rawBody].join(':');
-  const calculatedSignature = 'v0=' + crypto.createHmac('sha256', signingSecret).update(basestring).digest('hex');
+  const calculatedSignature = `v0=${  crypto.createHmac('sha256', signingSecret).update(basestring).digest('hex')}`;
   if (signatureToCompare) {
     // still broken
     const calculatedSignatureBuffer = Buffer.from(calculatedSignature, 'utf8');
@@ -37,12 +38,12 @@ function calculateSignature(
 function spoofMessage(
   msg,
   token = "52YK4N4phElR07An4dC59yMR", // optional
-  team_id = "TUMHGJ48G", // optional
+  teamID = "TUMHGJ48G", // optional
   channel = "CUM5CUN5A", // optional
-  api_app_id = "A02N5BNE13L", // optional
-  user_id = "UUPDE22F9", // optional
-  event_id = "Ev03HC9TGA86", // optional
-  auth_user_id = "U02N2D5FRB7", // optional
+  apiAppID = "A02N5BNE13L", // optional
+  userID = "UUPDE22F9", // optional
+  eventID = "Ev03HC9TGA86", // optional
+  authUserID = "U02N2D5FRB7", // optional
   ) {
 
   const now = Date.now();
@@ -50,13 +51,13 @@ function spoofMessage(
   const timestampHeader = nowSeconds.toString() // Get it from the request header x-slack-request-timestamp
   const inputBody = {
     "token": token,
-    "team_id": team_id,
-    "api_app_id": api_app_id,
+    "team_id": teamID,
+    "api_app_id": apiAppID,
     "event": {
       "client_msg_id": "220923fe-ac54-474b-839c-4aed523035eb",
       "type": "message",
       "text": msg,
-      "user": user_id,
+      "user": userID,
       "ts": "1653938696.488369",
       "team": "TUMHGJ48G",
       "blocks": [{
@@ -75,12 +76,12 @@ function spoofMessage(
       "channel_type": "channel"
     },
     "type": "event_callback",
-    "event_id": event_id,
+    "event_id": eventID,
     "event_time": nowSeconds,
     "authorizations": [{
       "enterprise_id": null,
-      "team_id": team_id,
-      "user_id": auth_user_id,
+      "team_id": teamID,
+      "user_id": authUserID,
       "is_bot": true,
       "is_enterprise_install": false
     }],
@@ -90,7 +91,7 @@ function spoofMessage(
   const contentType = "application/json" // Get it from the request header content-type
   const signingSecret = process.env.SLACK_SIGNING_SECRET
   
-  let sig = calculateSignature(
+  const sig = calculateSignature(
     timestampHeader,
     contentType,
     signingSecret,
@@ -99,7 +100,7 @@ function spoofMessage(
 
   const data = JSON.stringify(inputBody);
 
-  const res = axios.post('http://localhost:3000/slack/events', inputBody, {
+  axios.post('http://localhost:3000/slack/events', inputBody, {
     headers: {
       'Content-Type': 'application/json',
       'Content-Length': data.length,

--- a/src/spoof-message.js
+++ b/src/spoof-message.js
@@ -1,0 +1,116 @@
+require("./env");
+const crypto = require('crypto');
+const axios = require("axios");
+// const formurlencoded = require('form-urlencoded');
+
+// NOTES: bolt's App object requires valid credentials to initialize, so .env must contain valid credentials
+
+function calculateSignature(
+  timestampHeader, // Get it from the request header x-slack-request-timestamp
+  contentType, // Get it from the request header content-type
+  signingSecret,
+  body,
+  signatureToCompare = null, // Get it from the request header x-slack-signature
+){
+  // Based on: https://stackoverflow.com/a/70688396
+    
+  let rawBody;
+  if (contentType?.toLocaleLowerCase() === 'application/x-www-form-urlencoded') {
+    // Slash commands are sent in this content type
+    rawBody = formurlencoded(body);
+  } else {
+    var stringBody = JSON.stringify(body);
+    rawBody = stringBody.replace(/\//g, '\\/').replace(/[\u007f-\uffff]/g, (c) => '\\u' + ('0000' + c.charCodeAt(0).toString(16)).slice(-4));
+  }
+  const basestring = ['v0', timestampHeader, rawBody].join(':');
+  const calculatedSignature = 'v0=' + crypto.createHmac('sha256', signingSecret).update(basestring).digest('hex');
+  if (signatureToCompare) {
+    // still broken
+    const calculatedSignatureBuffer = Buffer.from(calculatedSignature, 'utf8');
+    const requestSignatureBuffer = Buffer.from(signatureToCompare, 'utf8');
+    const valid = crypto.timingSafeEqual(calculatedSignatureBuffer, requestSignatureBuffer)
+    return valid
+  }
+  return calculatedSignature;
+};
+
+function spoofMessage(
+  msg,
+  token = "52YK4N4phElR07An4dC59yMR", // optional
+  team_id = "TUMHGJ48G", // optional
+  channel = "CUM5CUN5A", // optional
+  api_app_id = "A02N5BNE13L", // optional
+  user_id = "UUPDE22F9", // optional
+  event_id = "Ev03HC9TGA86", // optional
+  auth_user_id = "U02N2D5FRB7", // optional
+  ) {
+
+  const now = Date.now();
+  const nowSeconds = Math.floor(now / 1000);
+  const timestampHeader = nowSeconds.toString() // Get it from the request header x-slack-request-timestamp
+  const inputBody = {
+    "token": token,
+    "team_id": team_id,
+    "api_app_id": api_app_id,
+    "event": {
+      "client_msg_id": "220923fe-ac54-474b-839c-4aed523035eb",
+      "type": "message",
+      "text": msg,
+      "user": user_id,
+      "ts": "1653938696.488369",
+      "team": "TUMHGJ48G",
+      "blocks": [{
+        "type": "rich_text",
+        "block_id": "A+m9",
+        "elements": [{
+          "type": "rich_text_section",
+          "elements": [{
+            "type": "text",
+            "text": msg
+          }]
+        }]
+      }],
+      "channel": channel,
+      "event_ts": "1653938696.488369",
+      "channel_type": "channel"
+    },
+    "type": "event_callback",
+    "event_id": event_id,
+    "event_time": nowSeconds,
+    "authorizations": [{
+      "enterprise_id": null,
+      "team_id": team_id,
+      "user_id": auth_user_id,
+      "is_bot": true,
+      "is_enterprise_install": false
+    }],
+    "is_ext_shared_channel": false,
+    "event_context": "4-eyJldCI6Im1lc3NhZ2UiLCJ0aWQiOiJUVU1IR0o0OEciLCJhaWQiOiJBMDJONUJORTEzTCIsImNpZCI6IkNVTTVDVU41QSJ9"
+  };
+  const contentType = "application/json" // Get it from the request header content-type
+  const signingSecret = process.env.SLACK_SIGNING_SECRET
+  
+  let sig = calculateSignature(
+    timestampHeader,
+    contentType,
+    signingSecret,
+    inputBody,
+  );
+
+  const data = JSON.stringify(inputBody);
+
+  const res = axios.post('http://localhost:3000/slack/events', inputBody, {
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': data.length,
+      'User-Agent': 'Slackbot 1.0 (+http://api.slack.com/robots)',
+      'Accept-Encoding': 'gzip,deflate',
+      'X-Slack-Request-Timestamp': timestampHeader,
+      'X-Slack-Signature': sig
+    }
+  });
+  
+}
+
+module.exports.calculateSignature = calculateSignature;
+module.exports.spoofMessage = spoofMessage;


### PR DESCRIPTION
**TLDR: Spoof incoming messages from slack instead of opening a public tunnel**

This doesn't require any incoming communication from slack servers, but the bolt app object does do an outgoing handshake when it wakes up, so you need a valid signing secret and bot token stored locally. Could probably spoof this handshake too, and fully isolate the local app, if needed. Waiting for a sanity check on whether any part of this PR is necessary/useful.

In spoof-message.js, we compute a valid signature that bolt will accept and construct a request that simulates the requests sent by slack's servers, which we POST to ://localhost/slack/events via axios.

**Steps to develop locally without a public tunnel (can also be done inside docker with extra debugger config):**

Run (only) pg in a container
```
docker compose -f database.local.yml up --build
```

Run charlie node outside container
```
npm start dev
```

Spoof a message to charlie
```
node -e 'require("./src/spoof-message").spoofMessage("dog fact or some similar message")'
```

At this point, one should be able to use any of the usual local node debugging tools/techniques. The primary intention here is to be able to use debugging niceties (breakpoints, etc...) that might be difficult to use when pushing to a remote instance.

**Note:** still a draft, needs testing and I don't think I've tried to push a slash command through it at all yet!