### PR TITLE
Update CodeQL to newer version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -25,43 +14,14 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+        queries: security-and-quality
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/src/scripts/pugs.test.js
+++ b/src/scripts/pugs.test.js
@@ -43,7 +43,7 @@ describe("pug bot", () => {
             type: "image",
             title: { type: "plain_text", text: "a pug!" },
             image_url: expect.stringMatching(
-              /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+              /^https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)$/
             ),
             alt_text: "a pug",
           },
@@ -69,7 +69,7 @@ describe("pug bot", () => {
               type: "image",
               title: { type: "plain_text", text: "a pug!" },
               image_url: expect.stringMatching(
-                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+                /^https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)$/
               ),
               alt_text: "a pug",
             },
@@ -77,7 +77,7 @@ describe("pug bot", () => {
               type: "image",
               title: { type: "plain_text", text: "a pug!" },
               image_url: expect.stringMatching(
-                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+                /^https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)$/
               ),
               alt_text: "a pug",
             },
@@ -94,7 +94,7 @@ describe("pug bot", () => {
               type: "image",
               title: { type: "plain_text", text: "a pug!" },
               image_url: expect.stringMatching(
-                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+                /^https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)$/
               ),
               alt_text: "a pug",
             },
@@ -102,7 +102,7 @@ describe("pug bot", () => {
               type: "image",
               title: { type: "plain_text", text: "a pug!" },
               image_url: expect.stringMatching(
-                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+                /^https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)$/
               ),
               alt_text: "a pug",
             },
@@ -110,7 +110,7 @@ describe("pug bot", () => {
               type: "image",
               title: { type: "plain_text", text: "a pug!" },
               image_url: expect.stringMatching(
-                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+                /^https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)$/
               ),
               alt_text: "a pug",
             },
@@ -127,7 +127,7 @@ describe("pug bot", () => {
               type: "image",
               title: { type: "plain_text", text: "a pug!" },
               image_url: expect.stringMatching(
-                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+                /^https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)$/
               ),
               alt_text: "a pug",
             },
@@ -135,7 +135,7 @@ describe("pug bot", () => {
               type: "image",
               title: { type: "plain_text", text: "a pug!" },
               image_url: expect.stringMatching(
-                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+                /^https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)$/
               ),
               alt_text: "a pug",
             },
@@ -143,7 +143,7 @@ describe("pug bot", () => {
               type: "image",
               title: { type: "plain_text", text: "a pug!" },
               image_url: expect.stringMatching(
-                /https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)/
+                /^https:\/\/i\.imgur\.com\/.{7}\.(jpg|png)$/
               ),
               alt_text: "a pug",
             },


### PR DESCRIPTION
The CodeQL v1 action [is being deprecated](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/) later this year. Let's just go ahead and update, then.