### PR TITLE
Change Inclusion Bot's reaction emoji

### DIFF
--- a/src/scripts/inclusion-bot.js
+++ b/src/scripts/inclusion-bot.js
@@ -76,7 +76,7 @@ module.exports = async (app) => {
       return;
     }
 
-    addEmojiReaction(msg, "inclusion-bot");
+    addEmojiReaction(msg, "wave");
 
     // Pick a random alternative
     const pretexts = specificMatch.map(({ alternatives, text }) => {

--- a/src/scripts/inclusion-bot.test.js
+++ b/src/scripts/inclusion-bot.test.js
@@ -156,7 +156,7 @@ triggers:
       msg.message.text = "hello this is the match 1 trigger";
       handler(msg);
 
-      expect(addEmojiReaction).toHaveBeenCalledWith(msg, "inclusion-bot");
+      expect(addEmojiReaction).toHaveBeenCalledWith(msg, "wave");
 
       expectedMessage.attachments[0].blocks[1].text.text =
         expect.stringMatching(
@@ -180,7 +180,7 @@ triggers:
       expectedMessage.attachments[0].blocks[1].accessory.value =
         "match 1|match 2a";
 
-      expect(addEmojiReaction).toHaveBeenCalledWith(msg, "inclusion-bot");
+      expect(addEmojiReaction).toHaveBeenCalledWith(msg, "wave");
 
       expectedMessage.attachments[0].blocks[1].text.text =
         expect.stringMatching(
@@ -199,7 +199,7 @@ triggers:
 
       expectedMessage.attachments[0].blocks[1].accessory.value = "match 2a";
 
-      expect(addEmojiReaction).toHaveBeenCalledWith(msg, "inclusion-bot");
+      expect(addEmojiReaction).toHaveBeenCalledWith(msg, "wave");
 
       expectedMessage.attachments[0].blocks[1].text.text =
         expect.stringMatching(
@@ -225,7 +225,7 @@ triggers:
 
       expectedMessage.attachments[0].blocks[1].accessory.value = "match 2a";
 
-      expect(addEmojiReaction).toHaveBeenCalledWith(msg, "inclusion-bot");
+      expect(addEmojiReaction).toHaveBeenCalledWith(msg, "wave");
 
       expectedMessage.attachments[0].blocks[1].text.text =
         expect.stringMatching(


### PR DESCRIPTION
Per [conversation on Slack](https://gsa-tts.slack.com/archives/C02FPFGBG/p1656524008103759), the `:inclusion-bot:` emoji kind of looks like a flashing bus and people have commented about getting hit by the inclusion bus. That's kind of funny in some ways, but it doesn't satisfy the purpose of the bot's reaction emoji. So this PR changes it to 👋.