### PR TITLE
Add a "help" command to Charlie

### DIFF
--- a/src/scripts/a11y.js
+++ b/src/scripts/a11y.js
@@ -1,8 +1,15 @@
 const {
+  helpMessage,
   stats: { incrementStats },
 } = require("../utils");
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "A11y bot",
+    "ask a11y",
+    "Ready to learn more about accessibility? A11y bot is here! Get a list of commands that A11y bot can respond to."
+  );
+
   app.message(/ask a(11|ll)y+$/i, async ({ say }) => {
     say({
       blocks: [

--- a/src/scripts/angry-tock.js
+++ b/src/scripts/angry-tock.js
@@ -4,9 +4,15 @@ const scheduler = require("node-schedule");
 const {
   slack: { postMessage, sendDirectMessage },
   tock: { get18FTockSlackUsers, get18FTockTruants },
+  helpMessage,
 } = require("../utils");
 
 module.exports = (app, config = process.env) => {
+  helpMessage.registerNonInteractive(
+    "Angry Tock",
+    "On the first morning of the work week, Angry Tock will disappointedly remind Tock-able users who haven't Tocked yet. At the end of the day, it'll also let supervisors know about folks who are still truant."
+  );
+
   const TOCK_API_URL = config.TOCK_API;
   const TOCK_TOKEN = config.TOCK_TOKEN;
 

--- a/src/scripts/coffeemate.js
+++ b/src/scripts/coffeemate.js
@@ -1,4 +1,5 @@
 const {
+  helpMessage,
   homepage,
   slack: { addEmojiReaction, postEphemeralResponse, sendDirectMessage },
   stats: { incrementStats },
@@ -16,6 +17,12 @@ const baseResponse = {
 };
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Coffeemate",
+    "coffee me",
+    "Coffeemate can help you schedule virtual coffees :coffee: with random teammates! The bot will add you to a queue of people looking for coffee and will match you with someone else in the queue. Have fun!"
+  );
+
   const addToCoffeeQueue = async (userId, message = false, scope = "") => {
     const key = `${brainKey}${scope}`;
     const queue = app.brain.get(key) || [];

--- a/src/scripts/dad-joke.js
+++ b/src/scripts/dad-joke.js
@@ -2,10 +2,18 @@ const { directMention } = require("@slack/bolt");
 const axios = require("axios");
 const {
   cache,
+  helpMessage,
   stats: { incrementStats },
 } = require("../utils");
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Dad Jokes",
+    "dad joke",
+    "Fetches a joke from Fatherhood.gov. Charlie will first set up the joke, then it'll provide the punchline!",
+    true
+  );
+
   app.message(
     directMention(),
     /dad joke/i,

--- a/src/scripts/define.js
+++ b/src/scripts/define.js
@@ -17,6 +17,7 @@ const he = require("he");
 const yaml = require("js-yaml");
 const {
   cache,
+  helpMessage,
   stats: { incrementStats },
 } = require("../utils");
 
@@ -93,6 +94,13 @@ const buildResponseText = (searchTerm, canonicalKey, glossary) => {
 };
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Glossary",
+    "(define or glossary) <term>",
+    "Not sure what something means? The TTS glossary might have something to help you, and Charlie gives you a shortcut to access the glossary directly from Slack.",
+    true
+  );
+
   app.message(
     directMention(),
     /(define|glossary) (.+)/i,

--- a/src/scripts/erg-inviter.js
+++ b/src/scripts/erg-inviter.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const yaml = require("js-yaml");
 const {
+  helpMessage,
   homepage: { registerInteractive },
   slack: { postMessage, sendDirectMessage },
   stats: { incrementStats },
@@ -20,6 +21,13 @@ const getERGs = () => {
 };
 
 module.exports = async (app) => {
+  helpMessage.registerInteractive(
+    "ERG Inviter",
+    "ergs",
+    "Charlie can send you a list of TTS employee resource and affinity groups that accept automated invitation requests. This command will send you a private message listing the ERGs and a button for each one to let the group know you'd like an invitation.",
+    true
+  );
+
   const ergs = module.exports.getERGs();
 
   const getButtons = () =>

--- a/src/scripts/fancy-font.js
+++ b/src/scripts/fancy-font.js
@@ -1,4 +1,5 @@
 const {
+  helpMessage,
   stats: { incrementStats },
 } = require("../utils");
 
@@ -59,6 +60,12 @@ const fancy = {
 };
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Fancy Font",
+    "fancy font <words>",
+    "Feeling fancy, and want your message to reflect that? Charlie is here to fancify your words!"
+  );
+
   app.message(/^fancy font (.*)$/i, ({ context, message, say }) => {
     incrementStats("fancy font");
 

--- a/src/scripts/federal-holidays-reminder.js
+++ b/src/scripts/federal-holidays-reminder.js
@@ -4,9 +4,15 @@ const {
   dates: { getNextHoliday },
   holidays: { emojis },
   slack: { postMessage },
+  helpMessage,
 } = require("../utils");
 
 const scheduleReminder = (config = process.env) => {
+  helpMessage.registerNonInteractive(
+    "Holiday reminders",
+    "On the business day before a federal holiday, Charlie will post a reminder in #general-talk. Talk the day off, don't do work for the government, and observe it in the way that is most suitable to you!"
+  );
+
   const CHANNEL = config.HOLIDAY_REMINDER_CHANNEL || "general";
   const TIMEZONE = config.HOLIDAY_REMINDER_TIMEZONE || "America/New_York";
   const reportingTime = moment(

--- a/src/scripts/federal-holidays.js
+++ b/src/scripts/federal-holidays.js
@@ -2,6 +2,7 @@ const { directMention } = require("@slack/bolt");
 const moment = require("moment");
 const {
   dates: { getNextHoliday },
+  helpMessage,
   holidays: { emojis },
   homepage: { registerDidYouKnow },
   stats: { incrementStats },
@@ -24,6 +25,13 @@ const getHolidayText = () => {
 };
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Federal holidays",
+    "when is the next holiday",
+    "Itching for a day off and want to know when the next holiday is? Charlie knows all the (standard, recurring) federal holidays and will gladly tell you what's coming up next!",
+    true
+  );
+
   registerDidYouKnow(() => ({
     type: "section",
     text: {

--- a/src/scripts/handbook.js
+++ b/src/scripts/handbook.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const {
+  helpMessage,
   slack: { postEphemeralResponse },
   stats: { incrementStats },
 } = require("../utils");
@@ -30,6 +31,12 @@ const getBlocksFromResults = (results) =>
   }, []);
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Handbook search",
+    "@handbook <terms>",
+    "Wondering if the TTS Handbook has useful information but don't want to open your browser? Charlie can search for you! If it finds anything, it'll post links in a threaded response."
+  );
+
   app.message(/^@?handbook (.+)$/i, async (msg) => {
     incrementStats("handbook search");
 

--- a/src/scripts/help.js
+++ b/src/scripts/help.js
@@ -1,0 +1,89 @@
+const { directMention } = require("@slack/bolt");
+const {
+  helpMessage: {
+    getHelp,
+    type: { interactive, noninteractive },
+  },
+  slack: { getSlackUsers },
+  stats: { incrementStats },
+} = require("../utils");
+
+module.exports = async (app) => {
+  incrementStats("help");
+
+  let botName = false;
+
+  app.message(
+    directMention(),
+    "help",
+    async ({
+      context: { botUserId },
+      event: { thread_ts: thread, ts },
+      say,
+    }) => {
+      if (botName === false) {
+        botName = (await getSlackUsers()).find(
+          (u) => u.id === botUserId
+        ).real_name;
+      }
+
+      const modules = getHelp();
+
+      const interactiveBots = [...modules.get(interactive)].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+      const noninteractiveBots = [...modules.get(noninteractive)].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+
+      const blocks = [
+        {
+          type: "header",
+          text: { type: "plain_text", text: "Interactive bots" },
+        },
+      ];
+
+      for (const bot of interactiveBots) {
+        blocks.push(
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `*${bot.name}*: ${bot.helpText}${
+                bot.directMention ? " (requires @-mentioning Charlie)" : ""
+              }\n\`\`\`${bot.directMention ? `@${botName} ` : ""}${
+                bot.trigger
+              }\`\`\``,
+            },
+          },
+          { type: "divider" }
+        );
+      }
+      // get rid of the last divider
+      blocks.pop();
+
+      blocks.push({
+        type: "header",
+        text: { type: "plain_text", text: "Non-interactive bots" },
+      });
+
+      for (const bot of noninteractiveBots) {
+        blocks.push(
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: `*${bot.name}*: ${bot.helpText}` },
+          },
+          { type: "divider" }
+        );
+      }
+      // get rid of the last divider
+      blocks.pop();
+
+      say({
+        blocks,
+        text: "Charlie help",
+        thread_ts: thread ?? ts,
+      });
+    }
+  );
+};

--- a/src/scripts/help.test.js
+++ b/src/scripts/help.test.js
@@ -1,0 +1,170 @@
+const {
+  getApp,
+  utils: {
+    helpMessage: { getHelp, type },
+    slack: { getSlackUsers },
+  },
+} = require("../utils/test");
+const help = require("./help");
+
+describe("Charlie self-help", () => {
+  const app = getApp();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("registers a help handler", () => {
+    help(app);
+
+    expect(app.message).toHaveBeenCalledWith(
+      expect.any(Function),
+      "help",
+      expect.any(Function)
+    );
+  });
+
+  describe("it renders a full block of helpful helpiness", () => {
+    const context = {
+      botUserId: "bot-id",
+    };
+
+    const say = jest.fn();
+
+    // The expected output assumes the mocked input below will be sorted and
+    // rendered correctly. It also assumes the bot's name will be properly
+    // fetched from the Slack API, given only a bot ID.
+    const expected = {
+      text: "Charlie help",
+      blocks: [
+        {
+          type: "header",
+          text: { type: "plain_text", text: "Interactive bots" },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*a bot*: Help for bot A\n```trigger a```",
+          },
+        },
+        { type: "divider" },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*b bot*: Also B bot helpy help (requires @-mentioning Charlie)\n```@the bot trigger b```",
+          },
+        },
+        { type: "divider" },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*z bot*: Bot Z also has help\n```trigger z```",
+          },
+        },
+        {
+          type: "header",
+          text: { type: "plain_text", text: "Non-interactive bots" },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*f bot*: flippity flop floop floop",
+          },
+        },
+        { type: "divider" },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*r bot*: rrrrrrrrrr",
+          },
+        },
+        { type: "divider" },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*t bot*: tater tater",
+          },
+        },
+      ],
+    };
+
+    let handler;
+
+    beforeEach(() => {
+      help(app);
+      handler = app.getHandler();
+
+      getSlackUsers.mockResolvedValue([
+        { id: "nobody", real_name: "not it" },
+        { id: "bot-id", real_name: "the bot" },
+      ]);
+
+      // This return value ensures that bots will be sorted before they are sent
+      // back to the user and that bots that require a direct mention are shown
+      // correctly. And that should cover most of the code paths in the bot.
+      getHelp.mockReturnValue(
+        new Map([
+          [
+            type.interactive,
+            [
+              {
+                name: "a bot",
+                helpText: "Help for bot A",
+                trigger: "trigger a",
+                directMention: false,
+              },
+              {
+                name: "z bot",
+                helpText: "Bot Z also has help",
+                trigger: "trigger z",
+                directMention: false,
+              },
+              {
+                name: "b bot",
+                helpText: "Also B bot helpy help",
+                trigger: "trigger b",
+                directMention: true,
+              },
+            ],
+          ],
+          [
+            type.noninteractive,
+            [
+              { name: "r bot", helpText: "rrrrrrrrrr" },
+              { name: "t bot", helpText: "tater tater" },
+              { name: "f bot", helpText: "flippity flop floop floop" },
+            ],
+          ],
+        ])
+      );
+    });
+
+    it("starts a thread if the message isn't already in one", async () => {
+      await handler({ context, event: { ts: "message timestamp" }, say });
+
+      expect(say).toHaveBeenCalledWith({
+        ...expected,
+        thread_ts: "message timestamp",
+      });
+    });
+
+    it("replies in the same thread as the triggering message", async () => {
+      await handler({
+        context,
+        event: { thread_ts: "thread timestamp", ts: "message timestamp" },
+        say,
+      });
+
+      expect(say).toHaveBeenCalledWith({
+        ...expected,
+        thread_ts: "thread timestamp",
+      });
+    });
+  });
+});

--- a/src/scripts/hugme.js
+++ b/src/scripts/hugme.js
@@ -18,6 +18,7 @@ const { directMention } = require("@slack/bolt");
 const CFENV = require("cfenv");
 const AWS = require("aws-sdk");
 const {
+  helpMessage,
   slack: { getChannelID },
   stats: { incrementStats },
 } = require("../utils");
@@ -27,6 +28,19 @@ module.exports = (app) => {
   const s3Creds = appEnv.getServiceCreds("charlie-bucket");
 
   if (s3Creds !== null) {
+    helpMessage.registerInteractive(
+      "Hug Me",
+      "hug me",
+      "Need a little hug in your life? Friends from TTS past have left us a gift, and Charlie will deliver one whenever you need!",
+      true
+    );
+    helpMessage.registerInteractive(
+      "Hug Bomb",
+      "hug bomb [number]",
+      "Need even more hug? Charlie will happily deliver more! Defaults to three simultaneous hugs.",
+      true
+    );
+
     const creds = new AWS.Credentials(
       s3Creds.access_key_id,
       s3Creds.secret_access_key

--- a/src/scripts/inclusion-bot.js
+++ b/src/scripts/inclusion-bot.js
@@ -4,6 +4,7 @@ const yaml = require("js-yaml");
 const {
   slack: { addEmojiReaction, postEphemeralResponse },
   stats: { incrementStats },
+  helpMessage,
 } = require("../utils");
 
 const capitalize = (str) => `${str[0].toUpperCase()}${str.slice(1)}`;
@@ -35,6 +36,11 @@ const getTriggers = () => {
 };
 
 module.exports = async (app) => {
+  helpMessage.registerNonInteractive(
+    "Inclusion bot",
+    "Charlie passively listens for language with racist, ableist, sexist, or other exclusionary histories. When it hears such words or phrases, it quietly lets the speaker know and offers some suggestions. What a great bot, helping nudge us all to thoughtful, inclusive language!"
+  );
+
   // Use the module exported version here, so that it can be stubbed for testing
   const { link, message, triggers } = module.exports.getTriggers();
 

--- a/src/scripts/love.js
+++ b/src/scripts/love.js
@@ -13,6 +13,7 @@
 //    None
 
 const {
+  helpMessage,
   slack: { getChannelID },
   stats: { incrementStats },
 } = require("../utils");
@@ -20,6 +21,12 @@ const {
 const LOVE_CHANNEL = "kudos";
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Love/Kudos bot",
+    "(love or :heart:) <user>",
+    "Someone just did something awesome and you want everyone to know it? Charlie's got you covered. Show your love and Charlie will share your message into the #kudos channel for everyone to see. Share the love!"
+  );
+
   app.message(
     /^\s*(love|<3|:heart\w*:)\s+((<@[\w-]+>\s*)+)(.*)$/i,
     async ({

--- a/src/scripts/opm_status.js
+++ b/src/scripts/opm_status.js
@@ -13,6 +13,7 @@
 const { directMention } = require("@slack/bolt");
 const axios = require("axios");
 const {
+  helpMessage,
   stats: { incrementStats },
 } = require("../utils");
 
@@ -24,6 +25,12 @@ const icons = {
 };
 
 module.exports = (robot) => {
+  helpMessage.registerInteractive(
+    "OPM's DC office status",
+    "opm status",
+    "Working in DC and want to know if the office is closed due to snow or, perhaps, raven attack? Charlie is good friends with the bots over at OPM and will gladly fetch that information for you. No more having to open a web browser all by yourself!"
+  );
+
   robot.message(
     directMention(),
     /opm status/i,

--- a/src/scripts/optimistic-tock.js
+++ b/src/scripts/optimistic-tock.js
@@ -5,9 +5,15 @@ const {
   optOut,
   slack: { sendDirectMessage },
   tock: { get18FTockTruants, get18FTockSlackUsers },
+  helpMessage,
 } = require("../utils");
 
 module.exports = async (app, config = process.env) => {
+  helpMessage.registerNonInteractive(
+    "Optimistic Tock",
+    "Near the end of the last day of the workweek, Charlie will remind Tockable people who haven't submitted their Tock yet."
+  );
+
   const TOCK_API_URL = config.TOCK_API;
   const TOCK_TOKEN = config.TOCK_TOKEN;
 

--- a/src/scripts/pugs.js
+++ b/src/scripts/pugs.js
@@ -1,5 +1,6 @@
 const { directMention } = require("@slack/bolt");
 const {
+  helpMessage,
   stats: { incrementStats },
 } = require("../utils");
 
@@ -35,6 +36,19 @@ const makePugs = (count = 1) =>
   }));
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Pug Me",
+    "pug me",
+    "Do you like pugs? Do you want a picture of a pug? Charlie can satisfy your craving with a random picture of a cute pug!",
+    true
+  );
+  helpMessage.registerInteractive(
+    "Pug Bomb",
+    "pug bomb <number>",
+    "Do you love pugs so much that you want to see several of them? Charlie can deliver! Defaults to three cutes.",
+    true
+  );
+
   app.message(directMention(), /pug me/i, async ({ say }) => {
     incrementStats("pug bot: one");
     say({ blocks: makePugs() });

--- a/src/scripts/q-expand.js
+++ b/src/scripts/q-expand.js
@@ -25,6 +25,7 @@ const { parse } = require("csv-parse");
 const fs = require("fs");
 const {
   stats: { incrementStats },
+  helpMessage,
 } = require("../utils");
 
 function getCsvData() {
@@ -111,6 +112,12 @@ function qExpander(expandThis, csvData) {
 }
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Q-Expander",
+    "qex [code]",
+    "Ever wonder what the Q* initialisms are after everyone's names? Each letter describes where a person fits in the organization. Charlie can show you what those codes mean in tree-form, so you can see the organizational hierarchy!"
+  );
+
   const csvData = module.exports.getCsvData();
   app.message(
     /^qexp?\s+([a-z0-9-]{1,8}\*?)$/i,

--- a/src/scripts/random-responses.js
+++ b/src/scripts/random-responses.js
@@ -4,6 +4,7 @@ const plural = require("plural");
 const {
   cache,
   stats: { incrementStats },
+  helpMessage,
 } = require("../utils");
 
 const loadConfigs = async () =>
@@ -141,9 +142,23 @@ const attachTrigger = (app, { trigger, ...config }) => {
 module.exports = async (app) => {
   const configs = await loadConfigs();
   if (Array.isArray(configs)) {
+    const triggers = [];
     configs.forEach(async (config) => {
+      triggers.push(
+        config.trigger
+          .replace(/\(\?<!.+?\)/, "")
+          .replace(/\(([^|]+)\|.+?\)/g, "$1")
+          .replace(/s\?$/, "")
+      );
       module.exports.attachTrigger(app, config);
     });
+    triggers.sort();
+
+    helpMessage.registerInteractive(
+      "Facts and random responses",
+      triggers.map((t) => `• ${t}`).join("\n"),
+      "Charlie knows *_so many_* facts. Dog facts, cat facts, giraffe facts, dolphin facts. There are just so many facts. Charlie will gladly share its knowledge of any of these!"
+    );
 
     app.message(/fact of facts/i, async (res) => {
       incrementStats("random response: fact of facts");

--- a/src/scripts/random-responses.test.js
+++ b/src/scripts/random-responses.test.js
@@ -294,7 +294,13 @@ describe("random responder", () => {
     const app = getApp();
 
     beforeEach(() => {
-      fs.readFileSync.mockReturnValue(`["config 1", "config 2", "config 3"]`);
+      const configs = [
+        { name: "config 1", trigger: "" },
+        { name: "config 2", trigger: "" },
+        { name: "config 3", trigger: "" },
+      ];
+
+      fs.readFileSync.mockReturnValue(JSON.stringify(configs));
     });
 
     it("attaches a trigger for each configuration", async () => {
@@ -302,9 +308,18 @@ describe("random responder", () => {
 
       await script(app);
 
-      expect(attachTrigger).toHaveBeenCalledWith(app, "config 1");
-      expect(attachTrigger).toHaveBeenCalledWith(app, "config 2");
-      expect(attachTrigger).toHaveBeenCalledWith(app, "config 3");
+      expect(attachTrigger).toHaveBeenCalledWith(app, {
+        name: "config 1",
+        trigger: "",
+      });
+      expect(attachTrigger).toHaveBeenCalledWith(app, {
+        name: "config 2",
+        trigger: "",
+      });
+      expect(attachTrigger).toHaveBeenCalledWith(app, {
+        name: "config 3",
+        trigger: "",
+      });
 
       expect(app.message).toHaveBeenCalledWith(
         /fact of facts/i,
@@ -327,7 +342,10 @@ describe("random responder", () => {
       // Confirm that a response handler for a random configuration was created
       // and that it was called.
       expect(random).toHaveBeenCalled();
-      expect(responseFrom).toHaveBeenCalledWith("config 1");
+      expect(responseFrom).toHaveBeenCalledWith({
+        name: "config 1",
+        trigger: "",
+      });
       expect(handler).toHaveBeenCalledWith("message");
 
       random.mockRestore();

--- a/src/scripts/three-paycheck-month.js
+++ b/src/scripts/three-paycheck-month.js
@@ -2,6 +2,7 @@ const { directMention } = require("@slack/bolt");
 const moment = require("moment");
 const {
   stats: { incrementStats },
+  helpMessage,
 } = require("../utils");
 
 // We need a known pay date to work from.
@@ -47,6 +48,13 @@ const getNextThreePaycheckMonth = (from = Date.now()) => {
 };
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Three-paycheck month",
+    "three paycheck",
+    "Sometimes we get three paychecks in a single month. Some people splurge on crab legs on those months, and Charlie can help you plan by letting you know when the next three-paycheck month is.",
+    true
+  );
+
   app.message(
     directMention(),
     // Be very permissive in what we listen for.e

--- a/src/scripts/timezone.js
+++ b/src/scripts/timezone.js
@@ -2,6 +2,7 @@ const moment = require("moment-timezone");
 const {
   optOut,
   slack: { getSlackUsersInConversation, postEphemeralMessage },
+  helpMessage,
 } = require("../utils");
 
 const TIMEZONES = {
@@ -33,6 +34,11 @@ const matcher =
   /(\d{1,2}:\d{2}\s?(am|pm)?)\s?(((ak|a|c|e|m|p)(s|d)?t)|:(eastern|central|mountain|pacific)-time-zone:)?/i;
 
 module.exports = (app) => {
+  helpMessage.registerNonInteractive(
+    "Helpful tau bot/Baby Tock",
+    "If Charlie sees something it recognizes as a time posted into chat, it will send a message that only you can see, letting you know what that time is in your timezone. Charlie tries really hard."
+  );
+
   const optout = optOut(
     "handy_tau_bot",
     "Baby Tock (Handy Tau Bot)",

--- a/src/scripts/tock-line.js
+++ b/src/scripts/tock-line.js
@@ -8,6 +8,7 @@
 const { directMention } = require("@slack/bolt");
 const {
   stats: { incrementStats },
+  helpMessage,
 } = require("../utils");
 
 const getTockLines = (app) => {
@@ -19,6 +20,19 @@ const getTockLines = (app) => {
 };
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Tock line (get)",
+    "tock line",
+    "Not sure what Tock line to bill this project to? Charlie might know! If someone has set a tock line for the channel, Charlie will gladly tell you what it is.",
+    true
+  );
+  helpMessage.registerInteractive(
+    "Tock line (set)",
+    "set tock line",
+    "Let Charlie help you keep track of the Tock line for a channel!",
+    true
+  );
+
   app.message(
     directMention(),
     /tock( line)?$/i,

--- a/src/scripts/travel-team.js
+++ b/src/scripts/travel-team.js
@@ -2,6 +2,7 @@ const holidays = require("@18f/us-federal-holidays");
 const moment = require("moment");
 const {
   stats: { incrementStats },
+  helpMessage,
 } = require("../utils");
 
 const closedDays = ["Saturday", "Sunday"];
@@ -47,6 +48,11 @@ const getHasRespondedToUserRecently = (userID) => {
 };
 
 module.exports = (robot) => {
+  helpMessage.registerNonInteractive(
+    "Travel team",
+    "Did you know that the TTS Travel team takes weekends and holidays too? It's true, they do! And Charlie knows it too. If you drop a question or comment in the travel channel on a closed day, Charlie will remind you that the office is closed and offer some helpful tips to get you through. It will also let you know when the Travel team will be back in the office!"
+  );
+
   robot.message(
     /.*/,
     async ({ client, event: { channel, thread_ts: thread, user }, say }) => {

--- a/src/scripts/zen.js
+++ b/src/scripts/zen.js
@@ -16,10 +16,18 @@
 const { directMention } = require("@slack/bolt");
 const axios = require("axios");
 const {
+  helpMessage,
   stats: { incrementStats },
 } = require("../utils");
 
 module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Zen Bot",
+    "zen",
+    "Fetches and displays a random product, techy, or code-focused message of zen. Read it, and breathe.",
+    true
+  );
+
   app.message(
     directMention(),
     /\bzen\b/i,

--- a/src/utils/helpMessage.js
+++ b/src/utils/helpMessage.js
@@ -1,0 +1,26 @@
+const interactive = Symbol("interactive");
+const noninteractive = Symbol("non-interactive");
+
+const modules = new Map([
+  [interactive, []],
+  [noninteractive, []],
+]);
+
+module.exports = {
+  getHelp() {
+    return modules;
+  },
+
+  registerInteractive(name, trigger, helpText, directMention = false) {
+    modules.get(interactive).push({ name, trigger, helpText, directMention });
+  },
+
+  registerNonInteractive(name, helpText) {
+    modules.get(noninteractive).push({ name, helpText });
+  },
+
+  type: {
+    interactive,
+    noninteractive,
+  },
+};

--- a/src/utils/helpMessage.test.js
+++ b/src/utils/helpMessage.test.js
@@ -1,0 +1,63 @@
+describe("help message registrar and reporter", () => {
+  const load = () =>
+    new Promise((resolve) => {
+      jest.isolateModules(() => {
+        const module = require("./helpMessage"); // eslint-disable-line global-require
+        resolve(module);
+      });
+    });
+
+  let helpMessage;
+
+  beforeEach(async () => {
+    helpMessage = await load();
+  });
+
+  describe("lets me register interactive bots", () => {
+    it("assumes a direct mention is not required", () => {
+      helpMessage.registerInteractive("bot", "trigger", "help text");
+
+      expect(helpMessage.getHelp().has(helpMessage.type.interactive)).toBe(
+        true
+      );
+      expect(helpMessage.getHelp().get(helpMessage.type.interactive)).toEqual([
+        {
+          name: "bot",
+          trigger: "trigger",
+          helpText: "help text",
+          directMention: false,
+        },
+      ]);
+    });
+
+    it("accepts the direct mention flag as an argument", () => {
+      helpMessage.registerInteractive("bot", "trigger", "help text", true);
+
+      expect(helpMessage.getHelp().has(helpMessage.type.interactive)).toBe(
+        true
+      );
+      expect(helpMessage.getHelp().get(helpMessage.type.interactive)).toEqual([
+        {
+          name: "bot",
+          trigger: "trigger",
+          helpText: "help text",
+          directMention: true,
+        },
+      ]);
+    });
+  });
+
+  it("lets me register noninteractive bots", () => {
+    helpMessage.registerNonInteractive("bot", "help text");
+
+    expect(helpMessage.getHelp().has(helpMessage.type.noninteractive)).toBe(
+      true
+    );
+    expect(helpMessage.getHelp().get(helpMessage.type.noninteractive)).toEqual([
+      {
+        name: "bot",
+        helpText: "help text",
+      },
+    ]);
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 const { cache } = require("./cache");
 const dates = require("./dates");
+const helpMessage = require("./helpMessage");
 const holidays = require("./holidays");
 const homepage = require("./homepage");
 const optOut = require("./optOut");
@@ -10,6 +11,7 @@ const tock = require("./tock");
 module.exports = {
   cache,
   dates,
+  helpMessage,
   holidays,
   homepage,
   optOut,

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -5,6 +5,7 @@ describe("utils / index", () => {
     expect(Object.keys(utils)).toEqual([
       "cache",
       "dates",
+      "helpMessage",
       "holidays",
       "homepage",
       "optOut",

--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -3,6 +3,7 @@ const brain = require("../brain");
 const {
   cache,
   dates,
+  helpMessage,
   homepage,
   optOut,
   slack,
@@ -89,6 +90,7 @@ module.exports = {
   utils: {
     cache,
     dates,
+    helpMessage,
     homepage,
     optOut,
     slack,


### PR DESCRIPTION
This can be triggered with `@Charlie help`, and it'll prompt the bot to tell you about all of its scripts. Scripts must register themselves to show up in the help listing.  Here's what it looks like:

![screenshot of Charlie listing its bots and how to use them](https://user-images.githubusercontent.com/1775733/179090089-a2667e2c-8597-47fa-bf56-7cea968a0da5.png)
