### PR TITLE
Q-expander: update Engineering Chapter cohort names.

### DIFF
--- a/config/q-expand.csv
+++ b/config/q-expand.csv
@@ -457,10 +457,11 @@ QUEAA,Engineering
 QUEAAA,A*SYNC Cohort 
 QUEAAB,Stingarrays Cohort
 QUEAAC,Quacks Cohort 🦆🦆
-QUEAAD,The Cohort Formerly Known as Chumanjalaal
-QUEAAE,Unnamed Cohort E
+QUEAAD,Dingobots
+formerQUEAAD,Chumanjalaal
+QUEAAE,Electronachos
 QUEAAF,Unnamed Cohort F
-QUEAAG,Unnamed Cohort G
+QUEAAG,Glamgoyles
 QUEAAH,QUEAAHH!! Real Monsters
 QUEAAI,Unnamed Cohort I
 QUEAAJ,Unnamed Cohort J


### PR DESCRIPTION
Time for some new names.
Goodbye to Chumanjalaal.
(Still an Easter egg…)

-----

Updates `config/q-expand.csv` to reflect these new Engineering cohort names: 

*   QUEAAD/Dingobots.
*   QUEAAE/Electronachos.
*   QUEAAG/Glamgoyles.