### PR TITLE
Fix the holiday reminder

### DIFF
--- a/src/scripts/federal-holidays-reminder.js
+++ b/src/scripts/federal-holidays-reminder.js
@@ -7,17 +7,19 @@ const {
   helpMessage,
 } = require("../utils");
 
-const scheduleReminder = (config = process.env) => {
-  helpMessage.registerNonInteractive(
-    "Holiday reminders",
-    "On the business day before a federal holiday, Charlie will post a reminder in #general-talk. Talk the day off, don't do work for the government, and observe it in the way that is most suitable to you!"
-  );
-
+// The first argument is always the bot object. We don't actually need it for
+// this script, so capture and toss it out.
+const scheduleReminder = (_, config = process.env) => {
   const CHANNEL = config.HOLIDAY_REMINDER_CHANNEL || "general";
   const TIMEZONE = config.HOLIDAY_REMINDER_TIMEZONE || "America/New_York";
   const reportingTime = moment(
     config.HOLIDAY_REMINDER_TIME || "15:00",
     "HH:mm"
+  );
+
+  helpMessage.registerNonInteractive(
+    "Holiday reminders",
+    `On the business day before a federal holiday, Charlie will post a reminder in #${CHANNEL}. Take the day off, don't do work for the government, and observe it in the way that is most suitable to you!`
   );
 
   const previousWeekday = (date) => {

--- a/src/scripts/federal-holidays-reminder.test.js
+++ b/src/scripts/federal-holidays-reminder.test.js
@@ -28,7 +28,7 @@ describe("holiday reminder", () => {
         };
         getNextHoliday.mockReturnValue(nextHoliday);
 
-        bot({});
+        bot(null, {});
         expect(scheduleJob).toHaveBeenCalledWith(
           moment(nextHoliday.date).subtract(3, "days").hour(15).toDate(),
           expect.any(Function)
@@ -41,7 +41,7 @@ describe("holiday reminder", () => {
         };
         getNextHoliday.mockReturnValue(nextHoliday);
 
-        bot({ HOLIDAY_REMINDER_TIME: "04:32" });
+        bot(null, { HOLIDAY_REMINDER_TIME: "04:32" });
         expect(scheduleJob).toHaveBeenCalledWith(
           moment(nextHoliday.date)
             .subtract(3, "days")
@@ -58,7 +58,7 @@ describe("holiday reminder", () => {
         const nextHoliday = { date: moment("2021-08-19T12:00:00Z") };
         getNextHoliday.mockReturnValue(nextHoliday);
 
-        bot();
+        bot(null);
         expect(scheduleJob).toHaveBeenCalledWith(
           moment(nextHoliday.date).subtract(1, "day").hour(15).toDate(),
           expect.any(Function)
@@ -69,7 +69,7 @@ describe("holiday reminder", () => {
         const nextHoliday = { date: moment("2021-08-19T12:00:00Z") };
         getNextHoliday.mockReturnValue(nextHoliday);
 
-        bot({ HOLIDAY_REMINDER_TIME: "04:32" });
+        bot(null, { HOLIDAY_REMINDER_TIME: "04:32" });
         expect(scheduleJob).toHaveBeenCalledWith(
           moment(nextHoliday.date)
             .subtract(1, "day")
@@ -92,7 +92,7 @@ describe("holiday reminder", () => {
       };
       getNextHoliday.mockReturnValue(nextHoliday);
 
-      bot(config);
+      bot(null, config);
 
       return scheduleJob.mock.calls[0][1];
     };


### PR DESCRIPTION
When I updated the holiday reminder script to take its configuration via an injected variable defaulting to the process environment variables (instead of always directly referring to environment variables; this was meant to be an enhancement to testability), I forgot that the first argument to scripts is ***always*** the bot object. So this:

```javascript
const scheduleReminder = (config = process.env) => {
  ...
};
```

Well, that just never works. The `config` variable is always set to the bot, not to environment variables. Then when the script checks for the channel, posting time, etc., it doesn't find them so it reverts to its own hardcoded defaults. The default channel is `general`, which does not exist in the TTS Slack, so the end result is this script just stopped announcing holidays beforehand.

![it's my fault](https://media.giphy.com/media/BRB7gSOKtQpbRbYUZ1/giphy.gif)

This PR fixes everything by capturing the first argument so the config will properly be the second argument, which is never populated by Charlie. That way it is still available to use for testing and at runtime it will default to environment variables.

While I was here, I also updated the help text to cite the configured channel instead of using the hardcoded default.