### PR TITLE
Use csv-parse to test CSV correctness

### DIFF
--- a/src/scripts/q-expand.test.js
+++ b/src/scripts/q-expand.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const { parse } = require("csv-parse");
 
 const { getApp } = require("../utils/test");
 const script = require("./q-expand");
@@ -244,13 +245,19 @@ describe("q-expand csv data", () => {
     }
   });
 
-  it("is formatted correctly", () => {
-    const csv = fs
-      .readFileSync("config/q-expand.csv", { encoding: "utf-8" })
-      .trim()
-      .split("\n");
-    const lines = csv.map((line) => line.split(","));
-    const invalid = lines.filter((parts) => parts.length !== 2);
-    expect(invalid.length).toBe(0);
-  });
+  it("is formatted correctly", async () =>
+    new Promise((resolve) => {
+      const rows = [];
+
+      fs.createReadStream("config/q-expand.csv")
+        .pipe(parse({ delimiter: "," }))
+        .on("data", (row) => {
+          rows.push(row);
+        })
+        .on("end", () => {
+          const invalid = rows.filter((row) => row.length !== 2);
+          expect(invalid.length).toBe(0);
+          resolve();
+        });
+    }));
 });


### PR DESCRIPTION
In #449, a test is failing because the test is attempting to "parse" the CSV by simply splitting on commas. However, it is valid for a CSV value to include commas if the value is wrapped in quotes. This PR updates the test to use the `csv-parse` library to parse the CSV and then counts the fields based on that.