### PR TITLE
Base holiday emoji on the displayed holiday name rather than the official holiday name

### DIFF
--- a/src/scripts/federal-holidays.js
+++ b/src/scripts/federal-holidays.js
@@ -15,7 +15,7 @@ const getHolidayText = () => {
     moment.duration(nextOne.utc().format("x") - Date.now()).asDays()
   );
 
-  const emoji = emojis.get(holiday.name);
+  const emoji = emojis.get(holiday.alsoObservedAs ?? holiday.name);
 
   return `The next federal holiday is ${
     holiday.alsoObservedAs ?? holiday.name
@@ -27,7 +27,7 @@ const getHolidayText = () => {
 module.exports = (app) => {
   helpMessage.registerInteractive(
     "Federal holidays",
-    "when is the next holiday",
+    "next holiday",
     "Itching for a day off and want to know when the next holiday is? Charlie knows all the (standard, recurring) federal holidays and will gladly tell you what's coming up next!",
     true
   );
@@ -40,12 +40,8 @@ module.exports = (app) => {
     },
   }));
 
-  app.message(
-    directMention(),
-    /(when is( the)? )?next (federal )?holiday/i,
-    ({ say }) => {
-      say(getHolidayText());
-      incrementStats("next federal holiday request");
-    }
-  );
+  app.message(directMention(), /next (federal )?holiday/i, ({ say }) => {
+    say(getHolidayText());
+    incrementStats("next federal holiday request");
+  });
 };


### PR DESCRIPTION
Also make the regex a little bit looser so it's easier to trigger without triggering accidentally.

Closes #469 

---

Checklist:

- [x] Code has been formatted with prettier
- N/A The `oauth.md` file has been updated if Charlie needs any new OAuth
      events or scopes
- N/A The `env.md` file has been updated if any changes have been made to the
      environment variables Charlie uses
- N/A The dev wiki has been updated, e.g.:
  - local development processes have changed
  - major development workflows have changed
  - internal utilities or APIs have changed
  - testing or deployment processes have changed
- N/A If appropriate, the NIST 800-218 documentation has been updated
