### PR TITLE
Don't send messages to users whose status message indicates they are OOO

### DIFF
--- a/src/scripts/angry-tock.js
+++ b/src/scripts/angry-tock.js
@@ -2,7 +2,7 @@ const holidays = require("@18f/us-federal-holidays");
 const moment = require("moment-timezone");
 const scheduler = require("node-schedule");
 const {
-  slack: { postMessage, sendDirectMessage },
+  slack: { postMessage, sendDirectMessage, slackUserIsOOO },
   tock: { get18FTockSlackUsers, get18FTockTruants },
   helpMessage,
 } = require("../utils");
@@ -58,12 +58,26 @@ module.exports = (app, config = process.env) => {
 
     const tockSlackUsers = await get18FTockSlackUsers();
     const truants = await get18FTockTruants(m());
-    const slackableTruants = tockSlackUsers.filter((tockUser) =>
-      truants.some((truant) => truant.email === tockUser.email)
+
+    const truantTockEmails = new Set(truants.map(({ email }) => email));
+
+    const slackableTruants = tockSlackUsers.filter(({ email }) =>
+      truantTockEmails.has(email)
     );
 
-    slackableTruants.forEach(({ slack_id: slackID }) => {
-      sendDirectMessage(slackID, message);
+    const userIsOOO = new Map(
+      await Promise.all(
+        slackableTruants.map(async ({ slack_id: id }) => [
+          id,
+          await slackUserIsOOO(id),
+        ])
+      )
+    );
+
+    slackableTruants.forEach(async ({ slack_id: slackID }) => {
+      if (!userIsOOO.get(slackID)) {
+        sendDirectMessage(slackID, message);
+      }
     });
 
     if (!calm) {
@@ -76,12 +90,18 @@ module.exports = (app, config = process.env) => {
         );
 
         const report = [];
-        slackableTruants.forEach((u) =>
-          report.push([`• <@${u.slack_id}> (notified on Slack)`])
-        );
-        nonSlackableTruants.forEach((u) =>
-          report.push([`• ${u.username} (not notified)`])
-        );
+        slackableTruants.forEach((u) => {
+          if (userIsOOO.get(u.slack_id)) {
+            report.push([
+              `• <@${u.slack_id}> (not notified on Slack - maybe OOO)`,
+            ]);
+          } else {
+            report.push([`• <@${u.slack_id}> (notified on Slack)`]);
+          }
+        });
+        nonSlackableTruants.forEach((u) => {
+          report.push([`• ${u.username} (not notified)`]);
+        });
 
         const truantReport = {
           attachments: [

--- a/src/scripts/optimistic-tock.js
+++ b/src/scripts/optimistic-tock.js
@@ -3,7 +3,7 @@ const moment = require("moment-timezone");
 const scheduler = require("node-schedule");
 const {
   optOut,
-  slack: { sendDirectMessage },
+  slack: { sendDirectMessage, slackUserIsOOO },
   tock: { get18FTockTruants, get18FTockSlackUsers },
   helpMessage,
 } = require("../utils");
@@ -61,7 +61,10 @@ module.exports = async (app, config = process.env) => {
 
     await Promise.all(
       truantTockSlackUsers.map(async ({ slack_id: slackID }) => {
-        await sendDirectMessage(slackID, message);
+        const isOOO = await slackUserIsOOO(slackID);
+        if (!isOOO) {
+          await sendDirectMessage(slackID, message);
+        }
       })
     );
   };

--- a/src/scripts/optimistic-tock.test.js
+++ b/src/scripts/optimistic-tock.test.js
@@ -4,7 +4,7 @@ const {
   getApp,
   utils: {
     optOut,
-    slack: { sendDirectMessage },
+    slack: { sendDirectMessage, slackUserIsOOO },
     tock: { get18FTockSlackUsers, get18FTockTruants },
   },
 } = require("../utils/test");
@@ -48,6 +48,20 @@ describe("Optimistic Tock", () => {
         last_name: "Two",
         username: "employee2",
       },
+      {
+        id: "tock4",
+        email: "user@four",
+        first_name: "User",
+        last_name: "Four",
+        username: "employee4",
+      },
+      {
+        id: "tock5",
+        email: "user@five",
+        first_name: "User",
+        last_name: "Five",
+        username: "employee5",
+      },
     ]);
 
     get18FTockSlackUsers.mockResolvedValue([
@@ -83,7 +97,25 @@ describe("Optimistic Tock", () => {
         user: "employee5",
         tz: "America/New_York",
       },
+      {
+        id: "tock6",
+        email: "user@six",
+        first_name: "User",
+        last_name: "Six",
+        slack_id: "slack 6",
+        username: "employee6",
+        tz: "America/New_York",
+      },
     ]);
+
+    slackUserIsOOO.mockImplementation((id) => {
+      switch (id) {
+        case "slack 5":
+          return true;
+        default:
+          return false;
+      }
+    });
   });
 
   afterAll(() => {

--- a/src/utils/slack.js
+++ b/src/utils/slack.js
@@ -98,6 +98,14 @@ const getSlackUsersInConversation = async ({
     return allUsers.filter(({ id }) => channelUsers.includes(id));
   });
 
+const getSlackUserStatusText = async (userId) =>
+  cache(`get status for user ${userId}`, 10, async () => {
+    const {
+      profile: { status_text: status },
+    } = await defaultClient.users.profile.get({ user: userId });
+    return status;
+  });
+
 const postEphemeralMessage = async (message, { SLACK_TOKEN } = process.env) => {
   await defaultClient.chat.postEphemeral({
     ...message,
@@ -147,14 +155,21 @@ const sendDirectMessage = async (
   );
 };
 
+const slackUserIsOOO = async (userId) => {
+  const statusText = await module.exports.getSlackUserStatusText(userId);
+  return /\b(ooo|out of( the)? office|vacation)\b/i.test(statusText);
+};
+
 module.exports = {
   addEmojiReaction,
   getChannelID,
   getSlackUsers,
   getSlackUsersInConversation,
+  getSlackUserStatusText,
   postEphemeralMessage,
   postEphemeralResponse,
   postMessage,
   sendDirectMessage,
   setClient,
+  slackUserIsOOO,
 };


### PR DESCRIPTION
* Adds a Slack utility method for fetching users' status text (the status message you can set yourself from Slack)
* Adds another Slack utility for getting a boolean whether a user is OOO or not
* Updates AngryTock and OptimisticTock to check users' OOO status and not pester people who are gone
* Updates all the tests too.

After review and approval, the wiki needs to be updated:
* A new OAuth scope is required: `users.profile:read` - the Charlie app will need to be reinstalled in the TTS workplace afterwards (which I _think_ I can do)
* Two new utility APIs need to be added to the documentation

---

Checklist:

- [x] Code has been formatted with prettier
- [ ] The `oauth.md` file has been updated if Charlie needs any new OAuth
      events or scopes
- N/A ~The `env.md` file has been updated if any changes have been made to the
      environment variables Charlie uses~
- [ ] The dev wiki has been updated, e.g.:
  - local development processes have changed
  - major development workflows have changed
  - internal utilities or APIs have changed
  - testing or deployment processes have changed
- N/A ~If appropriate, the NIST 800-218 documentation has been updated~
