### PR TITLE
Remind people not to overwork themselves in holiday weeks

### DIFF
--- a/src/scripts/federal-holidays-reminder.js
+++ b/src/scripts/federal-holidays-reminder.js
@@ -7,6 +7,16 @@ const {
   helpMessage,
 } = require("../utils");
 
+const workLessMessages = [
+  "Only do 32 hours worth of work since there are only 32 hours to do them in!",
+  "This is your permission to cancel some meetings and only do 32 hours of work for the holiday week!",
+  "Don't try to fit 40 hours of work into the holiday week 32-hour week!",
+  "Observe it the way that is most appropriate to you, and claim that 8 hours for yourself.",
+  "Work at your normal pace for the week and only do 32 hours worth!",
+  "Time is not compressed; it's just gone! So you can also get rid of 8 hours worth of work.",
+  "32 high-quality work hours are preferable to 40 hours worth of exhausted work crammed into 32 hours!",
+];
+
 // The first argument is always the bot object. We don't actually need it for
 // this script, so capture and toss it out.
 const scheduleReminder = (_, config = process.env) => {
@@ -44,7 +54,9 @@ const scheduleReminder = (_, config = process.env) => {
         "dddd"
       )}* is a federal holiday in observance of *${
         holiday.alsoObservedAs ?? holiday.name
-      }*${emoji ? ` ${emoji}` : ""}!`,
+      }*${emoji ? ` ${emoji}` : ""}! ${
+        workLessMessages[Math.floor(Math.random() * workLessMessages.length)]
+      }`,
     });
   };
 

--- a/src/scripts/federal-holidays-reminder.test.js
+++ b/src/scripts/federal-holidays-reminder.test.js
@@ -103,7 +103,9 @@ describe("holiday reminder", () => {
 
       expect(postMessage).toHaveBeenCalledWith({
         channel: "general",
-        text: "<!here|here> Remember that *Thursday* is a federal holiday in observance of *test holiday*!",
+        text: expect.stringMatching(
+          /^<!here\|here> Remember that \*Thursday\* is a federal holiday in observance of \*test holiday\*! .+$/
+        ),
       });
 
       // Sets up a job for tomorrow to schedule the next reminder. Because the
@@ -124,7 +126,9 @@ describe("holiday reminder", () => {
 
       expect(postMessage).toHaveBeenCalledWith({
         channel: "test channel",
-        text: "<!here|here> Remember that *Thursday* is a federal holiday in observance of *test holiday*!",
+        text: expect.stringMatching(
+          /^<!here\|here> Remember that \*Thursday\* is a federal holiday in observance of \*test holiday\*! .+$/
+        ),
       });
 
       // Sets up a job for tomorrow to schedule the next reminder
@@ -140,7 +144,9 @@ describe("holiday reminder", () => {
 
       expect(postMessage).toHaveBeenCalledWith({
         channel: "general",
-        text: "<!here|here> Remember that *Thursday* is a federal holiday in observance of *Veterans Day* :salute-you:!",
+        text: expect.stringMatching(
+          /^<!here|here> Remember that \*Thursday\* is a federal holiday in observance of \*Veterans Day\* :salute-you:! .+$/
+        ),
       });
 
       // Sets up a job for tomorrow to schedule the next reminder


### PR DESCRIPTION
This PR shifts an 18F norm into Charlie. For the last few years, 18F has made it a point to remind staff that they are expected to do less work during holiday weeks, as there is less working time to do it in. Holiday works have less time in them, so it is only reasonable that less should be done. Now Charlie will remind folks when it posts holiday reminders in Slack.

---

Checklist:

- [x] Code has been formatted with prettier
- other points are N/A