### PR TITLE
Revert "Don't send messages to users whose status message indicates they are OOO"

### DIFF
--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -3,7 +3,7 @@ const moment = require("moment-timezone");
 const {
   getApp,
   utils: {
-    slack: { postMessage, sendDirectMessage, slackUserIsOOO },
+    slack: { postMessage, sendDirectMessage },
     tock: { get18FTockSlackUsers, get18FTockTruants },
   },
 } = require("../utils/test");
@@ -58,13 +58,6 @@ describe("Angry Tock", () => {
         last_name: "Four",
         username: "employee4",
       },
-      {
-        id: "tock5",
-        email: "user@five",
-        first_name: "User",
-        last_name: "Five",
-        username: "employee5",
-      },
     ]);
 
     get18FTockSlackUsers.mockResolvedValue([
@@ -89,23 +82,7 @@ describe("Angry Tock", () => {
         slack_id: "slack3",
         user: "employee3",
       },
-      {
-        email: "user@five",
-        id: "tock5",
-        name: "User Five",
-        slack_id: "slack5",
-        user: "slack5",
-      },
     ]);
-
-    slackUserIsOOO.mockImplementation((id) => {
-      switch (id) {
-        case "slack5":
-          return true;
-        default:
-          return false;
-      }
-    });
   });
 
   afterAll(() => {
@@ -291,25 +268,15 @@ describe("Angry Tock", () => {
       text: ":angrytock: <https://tock.18f.gov|Tock your time>! You gotta!",
     });
 
-    // User 5 should be OOO, so make sure they weren't messaged
-    expect(sendDirectMessage).not.toHaveBeenCalledWith("slack5");
-
     expect(postMessage.mock.calls.length).toBe(2);
 
     const reportMessage = {
       attachments: [
         {
-          fallback: `
-• <@slack1> (notified on Slack)
-• <@slack2> (notified on Slack)
-• <@slack5> (not notified on Slack - maybe OOO)
-• employee4 (not notified)`.trim(),
+          fallback:
+            "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
           color: "#FF0000",
-          text: `
-• <@slack1> (notified on Slack)
-• <@slack2> (notified on Slack)
-• <@slack5> (not notified on Slack - maybe OOO)
-• employee4 (not notified)`.trim(),
+          text: "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
         },
       ],
       username: "Angry Tock",

--- a/src/scripts/optimistic-tock.js
+++ b/src/scripts/optimistic-tock.js
@@ -3,7 +3,7 @@ const moment = require("moment-timezone");
 const scheduler = require("node-schedule");
 const {
   optOut,
-  slack: { sendDirectMessage, slackUserIsOOO },
+  slack: { sendDirectMessage },
   tock: { get18FTockTruants, get18FTockSlackUsers },
   helpMessage,
 } = require("../utils");
@@ -61,10 +61,7 @@ module.exports = async (app, config = process.env) => {
 
     await Promise.all(
       truantTockSlackUsers.map(async ({ slack_id: slackID }) => {
-        const isOOO = await slackUserIsOOO(slackID);
-        if (!isOOO) {
-          await sendDirectMessage(slackID, message);
-        }
+        await sendDirectMessage(slackID, message);
       })
     );
   };

--- a/src/scripts/optimistic-tock.test.js
+++ b/src/scripts/optimistic-tock.test.js
@@ -4,7 +4,7 @@ const {
   getApp,
   utils: {
     optOut,
-    slack: { sendDirectMessage, slackUserIsOOO },
+    slack: { sendDirectMessage },
     tock: { get18FTockSlackUsers, get18FTockTruants },
   },
 } = require("../utils/test");
@@ -48,20 +48,6 @@ describe("Optimistic Tock", () => {
         last_name: "Two",
         username: "employee2",
       },
-      {
-        id: "tock4",
-        email: "user@four",
-        first_name: "User",
-        last_name: "Four",
-        username: "employee4",
-      },
-      {
-        id: "tock5",
-        email: "user@five",
-        first_name: "User",
-        last_name: "Five",
-        username: "employee5",
-      },
     ]);
 
     get18FTockSlackUsers.mockResolvedValue([
@@ -97,25 +83,7 @@ describe("Optimistic Tock", () => {
         user: "employee5",
         tz: "America/New_York",
       },
-      {
-        id: "tock6",
-        email: "user@six",
-        first_name: "User",
-        last_name: "Six",
-        slack_id: "slack 6",
-        username: "employee6",
-        tz: "America/New_York",
-      },
     ]);
-
-    slackUserIsOOO.mockImplementation((id) => {
-      switch (id) {
-        case "slack 5":
-          return true;
-        default:
-          return false;
-      }
-    });
   });
 
   afterAll(() => {

--- a/src/utils/slack.js
+++ b/src/utils/slack.js
@@ -98,14 +98,6 @@ const getSlackUsersInConversation = async ({
     return allUsers.filter(({ id }) => channelUsers.includes(id));
   });
 
-const getSlackUserStatusText = async (userId) =>
-  cache(`get status for user ${userId}`, 10, async () => {
-    const {
-      profile: { status_text: status },
-    } = await defaultClient.users.profile.get({ user: userId });
-    return status;
-  });
-
 const postEphemeralMessage = async (message, { SLACK_TOKEN } = process.env) => {
   await defaultClient.chat.postEphemeral({
     ...message,
@@ -155,21 +147,14 @@ const sendDirectMessage = async (
   );
 };
 
-const slackUserIsOOO = async (userId) => {
-  const statusText = await module.exports.getSlackUserStatusText(userId);
-  return /\b(ooo|out of( the)? office|vacation)\b/i.test(statusText);
-};
-
 module.exports = {
   addEmojiReaction,
   getChannelID,
   getSlackUsers,
   getSlackUsersInConversation,
-  getSlackUserStatusText,
   postEphemeralMessage,
   postEphemeralResponse,
   postMessage,
   sendDirectMessage,
   setClient,
-  slackUserIsOOO,
 };

--- a/src/utils/slack.test.js
+++ b/src/utils/slack.test.js
@@ -1,24 +1,20 @@
-const slack = require("./slack");
-
 const {
   addEmojiReaction,
   getChannelID,
   getSlackUsers,
   getSlackUsersInConversation,
-  getSlackUserStatusText,
   postEphemeralMessage,
   postEphemeralResponse,
   postMessage,
   sendDirectMessage,
   setClient,
-  slackUserIsOOO,
-} = slack;
+} = require("./slack");
 
 describe("utils / slack", () => {
   const defaultClient = {
     chat: { postEphemeral: jest.fn(), postMessage: jest.fn() },
     conversations: { list: jest.fn(), open: jest.fn() },
-    users: { list: jest.fn(), profile: { get: jest.fn() } },
+    users: { list: jest.fn() },
   };
   const config = { SLACK_TOKEN: "slack token" };
 
@@ -152,19 +148,6 @@ describe("utils / slack", () => {
     ]);
   });
 
-  it("gets a Slack user's status text", async () => {
-    defaultClient.users.profile.get.mockResolvedValue({
-      profile: { status_text: "text" },
-    });
-
-    const status = await getSlackUserStatusText("slack id");
-
-    expect(defaultClient.users.profile.get).toHaveBeenCalledWith({
-      user: "slack id",
-    });
-    expect(status).toEqual("text");
-  });
-
   it("can post an ephemeral message", async () => {
     const msg = { this: "is", my: "message" };
 
@@ -243,49 +226,6 @@ describe("utils / slack", () => {
       channel: "direct message id",
       text: "moop moop",
       token: "slack token",
-    });
-  });
-
-  describe("tells you if a user is OOO", () => {
-    slack.getSlackUserStatusText = jest.fn();
-
-    it("says no if their status is empty", async () => {
-      slack.getSlackUserStatusText.mockResolvedValue("");
-      const isOOO = await slackUserIsOOO("bob");
-
-      expect(isOOO).toEqual(false);
-    });
-
-    describe("says yes if...", () => {
-      it("their status is OOO, but with mixed caps (case-insensitive check)", async () => {
-        slack.getSlackUserStatusText.mockResolvedValue("I am OoO for a while");
-        const isOOO = await slackUserIsOOO("bob");
-
-        expect(isOOO).toEqual(true);
-      });
-
-      it("their status is 'out of office'", async () => {
-        slack.getSlackUserStatusText.mockResolvedValue("out of office");
-        const isOOO = await slackUserIsOOO("bob");
-
-        expect(isOOO).toEqual(true);
-      });
-
-      it("their status is 'out of the office'", async () => {
-        slack.getSlackUserStatusText.mockResolvedValue(
-          "I will be out of the office until I am not"
-        );
-        const isOOO = await slackUserIsOOO("bob");
-
-        expect(isOOO).toEqual(true);
-      });
-
-      it("their status mentions vacation", async () => {
-        slack.getSlackUserStatusText.mockResolvedValue("On vacation, friends!");
-        const isOOO = await slackUserIsOOO("bob");
-
-        expect(isOOO).toEqual(true);
-      });
     });
   });
 });


### PR DESCRIPTION
Reverts 18F/charlie#471

Optimistic and Angry Tock both seem to have stopped working entirely. I can't reproduce the problem in staging, but there is a hint: the production logs and my staging tests have both triggered rate limiting warnings. Possibly querying each user's status is pushing us over the rate limit and that's causing problems. Bolt is supposed to handle rate limit warnings and automatically retry requests after the specified cooldown, and since Charlie is asynchronously waiting for Bolt, that ***should*** still be fine, but #471 is the only recent change to Tock reporting and at least one user mentioned in #bots that they didn't get a reminder after it was merged.

Some thoughts for revisiting this in the future:

1. It may not be necessary to fetch the entire list of Slack users every time. Once we've correlated a Slack ID to a Tock ID, we can store that info in Charlie's brain. Then we'd only need to fetch the list of Slack users if there is a truant Tock user whose Slack ID we don't know.
2. The list of all Slack users includes users' status text, so if we do continue to fetch the complete list every time, we can extract users' status texts from that instead of doing separate lookups for each truant user.