### PR TITLE
Refactor ops reports for Tock truancy out of Angry Tock

### DIFF
--- a/.github/workflows/on_pull_request_tock_ops.yml
+++ b/.github/workflows/on_pull_request_tock_ops.yml
@@ -1,0 +1,23 @@
+name: tock ops report changes
+
+on:
+  pull_request:
+    paths:
+      - src/scripts/tock-truant-ops-report.js
+      - src/scripts/tock-truant-ops-report.test.js
+
+jobs:
+  comment:
+    name: leave a comment
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "It looks like you're updating the Tock truancy report. Please ensure that the 18F director of operations is aware of these changes because the Tock truancy report is used by the ops team and needs to function."
+            });

--- a/src/scripts/angry-tock.js
+++ b/src/scripts/angry-tock.js
@@ -2,6 +2,7 @@ const holidays = require("@18f/us-federal-holidays");
 const moment = require("moment-timezone");
 const scheduler = require("node-schedule");
 const {
+  dates: { getCurrentWorkWeek },
   slack: { sendDirectMessage },
   tock: { get18FTockSlackUsers, get18FTockTruants },
   helpMessage,
@@ -27,13 +28,6 @@ module.exports = (app, config = process.env) => {
   );
 
   /**
-   * Get the current time in the configured timezone.
-   * @returns {Moment} A moment object representing the current time in the
-   *   configured timezone.
-   */
-  const m = () => moment.tz(ANGRY_TOCK_TIMEZONE);
-
-  /**
    * Shout at all the truant users.
    * @async
    * @param {Object} options
@@ -50,7 +44,7 @@ module.exports = (app, config = process.env) => {
     };
 
     const tockSlackUsers = await get18FTockSlackUsers();
-    const truants = await get18FTockTruants(m());
+    const truants = await get18FTockTruants(moment.tz(ANGRY_TOCK_TIMEZONE));
     const slackableTruants = tockSlackUsers.filter((tockUser) =>
       truants.some((truant) => truant.email === tockUser.email)
     );
@@ -60,69 +54,69 @@ module.exports = (app, config = process.env) => {
     });
   };
 
-  /**
-   * Gets whether or not a given date/time is a Angry Tock shouting day.
-   * @param {Moment} now The date/time to check, as a Moment object
-   * @returns {Boolean} True if the passed date/time is a good day for shouting
-   */
-  const isAngryTockDay = (now) => {
-    const d = now || m();
-    return d.format("dddd") === "Monday" && !holidays.isAHoliday(d.toDate());
+  const getNextShoutingDay = () => {
+    // The reporting time for the current work week would be the first day of
+    // that working week.
+    const reportTime = moment
+      .tz(getCurrentWorkWeek()[0], ANGRY_TOCK_TIMEZONE)
+      .hour(ANGRY_TOCK_SECOND_ALERT.hour())
+      .minute(ANGRY_TOCK_SECOND_ALERT.minute())
+      .second(0);
+
+    // If we've already passed the truancy report time for the current work week,
+    // jump to the next Monday, and then scoot forward over any holidays.
+    if (reportTime.isBefore(moment())) {
+      reportTime.add(7, "days").day(1);
+      while (holidays.isAHoliday(reportTime.toDate())) {
+        reportTime.add(1, "day");
+      }
+    }
+
+    return reportTime;
   };
 
   /**
    * Schedules the next time to shout at users.
    */
   const scheduleNextShoutingMatch = () => {
-    const day = moment.tz(ANGRY_TOCK_TIMEZONE);
+    const now = moment();
+    const day = getNextShoutingDay();
 
     const firstHour = ANGRY_TOCK_FIRST_ALERT.hour();
     const firstMinute = ANGRY_TOCK_FIRST_ALERT.minute();
-    const firstTockShoutTime = day.clone();
-    firstTockShoutTime.hour(firstHour);
-    firstTockShoutTime.minute(firstMinute);
-    firstTockShoutTime.second(0);
 
-    const secondHour = ANGRY_TOCK_SECOND_ALERT.hour();
-    const secondMinute = ANGRY_TOCK_SECOND_ALERT.minute();
-    const secondTockShoutTime = day.clone();
-    secondTockShoutTime.hour(secondHour);
-    secondTockShoutTime.minute(secondMinute);
-    secondTockShoutTime.second(0);
+    const firstTockShoutTime = day
+      .clone()
+      .hour(firstHour)
+      .minute(firstMinute)
+      .second(0);
 
-    if (isAngryTockDay(day)) {
-      // If today is the normal day for Angry Tock to shout...
-      if (day.isBefore(firstTockShoutTime)) {
-        // ...and Angry Tock should not have shouted at all yet, schedule a calm
-        // shout.
-        return scheduler.scheduleJob(firstTockShoutTime.toDate(), async () => {
-          await shout({ calm: true });
-          setTimeout(() => scheduleNextShoutingMatch(), 1000);
-        });
-      }
-      if (day.isBefore(secondTockShoutTime)) {
-        // ...and Angry Tock should have shouted once, schedule an un-calm shout.
-        return scheduler.scheduleJob(secondTockShoutTime.toDate(), async () => {
-          setTimeout(() => scheduleNextShoutingMatch(), 1000);
-          await shout({ calm: false });
-        });
-      }
+    const secondTockShoutTime = day
+      .clone()
+      .hour(ANGRY_TOCK_SECOND_ALERT.hour())
+      .minute(ANGRY_TOCK_SECOND_ALERT.minute())
+      .second(0);
 
-      // ...and Angry Tock should have shouted twice already, advance a day and
-      // schedule a shout for next week.
-      day.add(1, "day");
+    // If today is the normal day for Angry Tock to shout...
+    if (now.isBefore(firstTockShoutTime)) {
+      // ...and Angry Tock should not have shouted at all yet, schedule a calm
+      // shout.
+      return scheduler.scheduleJob(firstTockShoutTime.toDate(), async () => {
+        await shout({ calm: true });
+        setTimeout(() => scheduleNextShoutingMatch(), 1000);
+      });
     }
 
-    // ...and Angry Tock should have already shouted twice today, advance to the
-    // next shouting day.
-    while (!isAngryTockDay(day)) {
-      day.add(1, "day");
+    if (now.isBefore(secondTockShoutTime)) {
+      // ...and Angry Tock should have shouted once, schedule an un-calm shout.
+      return scheduler.scheduleJob(secondTockShoutTime.toDate(), async () => {
+        setTimeout(() => scheduleNextShoutingMatch(), 1000);
+        await shout({ calm: false });
+      });
     }
 
     // Schedule a calm shout for the next shouting day.
-    day.hour(firstHour);
-    day.minute(firstMinute);
-    day.second(0);
+    day.hour(firstHour).minute(firstMinute).second(0);
 
     return scheduler.scheduleJob(day.toDate(), async () => {
       setTimeout(() => scheduleNextShoutingMatch(), 1000);

--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -227,7 +227,6 @@ describe("Angry Tock", () => {
     const calmShout = scheduleJob.mock.calls[0][1];
     await calmShout();
 
-    expect(postMessage.mock.calls.length).toBe(0);
     expect(sendDirectMessage.mock.calls.length).toBe(2);
 
     expect(sendDirectMessage).toHaveBeenCalledWith("slack1", {
@@ -244,7 +243,6 @@ describe("Angry Tock", () => {
 
     // Reset stub history so we can be more sure about the next step.
     scheduleJob.mockClear();
-    postMessage.mockClear();
     sendDirectMessage.mockClear();
 
     // After the calm "shout", there's a short delay and then an "angry" shout
@@ -268,59 +266,13 @@ describe("Angry Tock", () => {
       text: ":angrytock: <https://tock.18f.gov|Tock your time>! You gotta!",
     });
 
-    expect(postMessage.mock.calls.length).toBe(2);
-
-    const reportMessage = {
-      attachments: [
-        {
-          fallback:
-            "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
-          color: "#FF0000",
-          text: "• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)",
-        },
-      ],
-      username: "Angry Tock",
-      icon_emoji: ":angrytock:",
-      text: "*The following users are currently truant on Tock:*",
-    };
-
-    expect(postMessage).toHaveBeenCalledWith({
-      ...reportMessage,
-      channel: "#channel",
-    });
-    expect(postMessage).toHaveBeenCalledWith({
-      ...reportMessage,
-      channel: "@user",
-    });
-
     // Clear everything out again, and make sure that the "angry" shout turns
     // very happy if there aren't any truants.
-    postMessage.mockClear();
     sendDirectMessage.mockClear();
 
     get18FTockTruants.mockResolvedValue([]);
     await angryShout();
 
-    const happyMessage = {
-      username: "Happy Tock",
-      icon_emoji: ":happy-tock:",
-      text: "No Tock truants!",
-    };
-
-    expect(postMessage.mock.calls.length).toBe(3);
     expect(sendDirectMessage.mock.calls.length).toBe(0);
-
-    expect(postMessage).toHaveBeenCalledWith({
-      ...happyMessage,
-      channel: "#channel",
-    });
-    expect(postMessage).toHaveBeenCalledWith({
-      ...happyMessage,
-      channel: "@user",
-    });
-    expect(postMessage).toHaveBeenCalledWith({
-      ...happyMessage,
-      channel: "#happy",
-    });
   });
 });

--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -3,7 +3,8 @@ const moment = require("moment-timezone");
 const {
   getApp,
   utils: {
-    slack: { postMessage, sendDirectMessage },
+    dates: { getCurrentWorkWeek },
+    slack: { sendDirectMessage },
     tock: { get18FTockSlackUsers, get18FTockTruants },
   },
 } = require("../utils/test");
@@ -121,6 +122,8 @@ describe("Angry Tock", () => {
           );
           jest.setSystemTime(time.toDate());
 
+          getCurrentWorkWeek.mockReturnValue([time.toDate()]);
+
           angryTock(app, config);
 
           time.hour(10);
@@ -140,6 +143,8 @@ describe("Angry Tock", () => {
               config.ANGRY_TOCK_TIMEZONE
             );
             jest.setSystemTime(time.toDate());
+
+            getCurrentWorkWeek.mockReturnValue([time.toDate()]);
 
             angryTock(app, config);
 
@@ -163,6 +168,8 @@ describe("Angry Tock", () => {
               config.ANGRY_TOCK_TIMEZONE
             );
             jest.setSystemTime(initial.toDate());
+
+            getCurrentWorkWeek.mockReturnValue([initial.toDate()]);
 
             angryTock(app, config);
 
@@ -192,6 +199,8 @@ describe("Angry Tock", () => {
         );
         jest.setSystemTime(initial.toDate());
 
+        getCurrentWorkWeek.mockReturnValue([initial.clone().day(1).toDate()]);
+
         angryTock(app, config);
 
         // Monday, October 21, 2019 - World's oldest natural pearl, dated at 8,000
@@ -216,6 +225,8 @@ describe("Angry Tock", () => {
       config.ANGRY_TOCK_TIMEZONE
     );
     jest.setSystemTime(initial.toDate());
+
+    getCurrentWorkWeek.mockReturnValue([initial.toDate()]);
 
     angryTock(app, config);
 

--- a/src/scripts/hugme.js
+++ b/src/scripts/hugme.js
@@ -107,6 +107,6 @@ module.exports = (app) => {
       }
     );
   } else {
-    console.log("Unable to find service creds for 'charlie-bucket'.");
+    app.logger.warn("Unable to find service creds for 'charlie-bucket'.");
   }
 };

--- a/src/scripts/tock-truant-ops-report.js
+++ b/src/scripts/tock-truant-ops-report.js
@@ -85,7 +85,7 @@ module.exports = (app, config = process.env) => {
       // Once we've run the report, wait a minute and then schedule the next
       setTimeout(() => {
         scheduleNextReport();
-      }, 60 * 1000);
+      }, 60 * 1000).unref();
     });
   };
 

--- a/src/scripts/tock-truant-ops-report.js
+++ b/src/scripts/tock-truant-ops-report.js
@@ -1,0 +1,93 @@
+const holidays = require("@18f/us-federal-holidays");
+const moment = require("moment-timezone");
+const scheduler = require("node-schedule");
+const {
+  dates: { getCurrentWorkWeek },
+  slack: { postMessage },
+  tock: { get18FTockTruants },
+} = require("../utils");
+
+module.exports = (app, config = process.env) => {
+  if (!config.TOCK_API || !config.TOCK_TOKEN) {
+    app.logger.warn(
+      "Tock truant report disabled: Tock API URL or access token is not set"
+    );
+    return;
+  }
+
+  const TRUANT_REPORT_TIMEZONE =
+    config.ANGRY_TOCK_TIMEZONE || "America/New_York";
+  const TRUANT_REPORT_TIME = moment(
+    config.ANGRY_TOCK_SECOND_TIME || "16:00",
+    "HH:mm"
+  );
+
+  const TRUANT_REPORT_TO = (config.ANGRY_TOCK_REPORT_TO || "#18f-supes").split(
+    ","
+  );
+
+  const getNextTruantReportTime = () => {
+    // The reporting time for the current work week would be the first day of
+    // that working week.
+    const reportTime = moment
+      .tz(getCurrentWorkWeek()[0], TRUANT_REPORT_TIMEZONE)
+      .hour(TRUANT_REPORT_TIME.hour())
+      .minute(TRUANT_REPORT_TIME.minute())
+      .second(0);
+
+    // If we've already passed the truancy report time for the current work week,
+    // jump to the next Monday, and then scoot forward over any holidays.
+    if (reportTime.isBefore(moment())) {
+      reportTime.add(7, "days").day(1);
+      while (holidays.isAHoliday(reportTime.toDate())) {
+        reportTime.add(1, "day");
+      }
+    }
+
+    return reportTime;
+  };
+
+  const report = async () => {
+    const truants = await get18FTockTruants(moment.tz(TRUANT_REPORT_TIMEZONE));
+
+    if (truants.length > 0) {
+      const truantList = truants
+        .map(({ username }) => `• ${username}`)
+        .join("\n");
+
+      const truantReport = {
+        attachments: [
+          {
+            fallback: truantList,
+            color: "#FF0000",
+            text: truantList,
+          },
+        ],
+        username: "Angry Tock",
+        icon_emoji: ":angrytock:",
+        text: "*The following users are currently truant on Tock:*",
+      };
+
+      await Promise.all(
+        TRUANT_REPORT_TO.map((channel) =>
+          postMessage({ ...truantReport, channel })
+        )
+      );
+    }
+  };
+
+  const scheduleNextReport = () => {
+    const when = getNextTruantReportTime();
+
+    scheduler.scheduleJob(when.toDate(), async () => {
+      await report();
+
+      // Once we've run the report, wait a minute and then schedule the next
+      setTimeout(() => {
+        scheduleNextReport();
+      }, 60 * 1000);
+    });
+  };
+
+  scheduleNextReport();
+};

--- a/src/scripts/tock-truant-ops-report.test.js
+++ b/src/scripts/tock-truant-ops-report.test.js
@@ -21,6 +21,7 @@ describe("Tock truancy reporter for ops", () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    postMessage.mockResolvedValue(null);
   });
 
   describe("initialization", () => {
@@ -254,6 +255,7 @@ describe("Tock truancy reporter for ops", () => {
     let reportFn;
 
     beforeAll(() => {
+      getCurrentWorkWeek.mockReturnValue([new Date()]);
       script(app, { TOCK_API: "api", TOCK_TOKEN: "token" });
       reportFn = scheduleJob.mock.calls[0][1];
     });

--- a/src/scripts/tock-truant-ops-report.test.js
+++ b/src/scripts/tock-truant-ops-report.test.js
@@ -1,0 +1,309 @@
+const moment = require("moment-timezone");
+const {
+  getApp,
+  utils: {
+    dates: { getCurrentWorkWeek },
+    tock: { get18FTockTruants },
+    slack: { postMessage },
+  },
+} = require("../utils/test");
+
+describe("Tock truancy reporter for ops", () => {
+  const app = getApp();
+
+  const scheduleJob = jest.fn();
+  jest.doMock("node-schedule", () => ({ scheduleJob }));
+
+  // Load this module *after* everything gets mocked. Otherwise the module will
+  // load the unmocked stuff and the tests won't work.
+  // eslint-disable-next-line global-require
+  const script = require("./tock-truant-ops-report");
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("initialization", () => {
+    describe("does not register itself", () => {
+      it("if TOCK_API and TOCK_TOKEN are unset", () => {
+        script(app);
+        expect(app.logger.warn).toHaveBeenCalled();
+        expect(scheduleJob).not.toHaveBeenCalled();
+      });
+
+      it("if only TOCK_API is unset", () => {
+        script(app, { TOCK_TOKEN: "token" });
+        expect(app.logger.warn).toHaveBeenCalled();
+        expect(scheduleJob).not.toHaveBeenCalled();
+      });
+
+      it("if only TOCK_TOKEN is unset", () => {
+        script(app, { TOCK_API: "api" });
+        expect(app.logger.warn).toHaveBeenCalled();
+        expect(scheduleJob).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("registers itself", () => {
+      it("if TOCK_API and TOCK_TOKEN are both set", () => {
+        getCurrentWorkWeek.mockReturnValue([new Date()]);
+        script(app, { TOCK_API: "api", TOCK_TOKEN: "token" });
+        expect(app.logger.warn).not.toHaveBeenCalled();
+        expect(scheduleJob).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("schedules future reports", () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    describe("using configurated values", () => {
+      const NOW = moment.tz("2022-11-14T12:00:00", "America/New_York").toDate();
+      beforeEach(() => {
+        jest.setSystemTime(NOW);
+      });
+
+      it("honors ANGRY_TOCK_TIMEZONE", () => {
+        getCurrentWorkWeek.mockReturnValue([NOW]);
+
+        script(app, {
+          TOCK_API: true,
+          TOCK_TOKEN: true,
+          ANGRY_TOCK_TIMEZONE: "America/Los_Angeles",
+        });
+
+        const expected = moment.tz(
+          "2022-11-14T16:00:00",
+          "America/Los_Angeles"
+        );
+
+        expect(scheduleJob).toHaveBeenCalledWith(
+          expected.toDate(),
+          expect.any(Function)
+        );
+      });
+
+      it("honors ANGRY_TOCK_SECOND_TIME", () => {
+        getCurrentWorkWeek.mockReturnValue([NOW]);
+
+        script(app, {
+          TOCK_API: true,
+          TOCK_TOKEN: true,
+          ANGRY_TOCK_SECOND_TIME: "13:47",
+        });
+
+        const expected = moment.tz("2022-11-14T13:47:00", "America/New_York");
+
+        expect(scheduleJob).toHaveBeenCalledWith(
+          expected.toDate(),
+          expect.any(Function)
+        );
+      });
+
+      it("honors ANGRY_TOCK_REPORT_TO", async () => {
+        getCurrentWorkWeek.mockReturnValue([NOW]);
+        get18FTockTruants.mockReturnValue([{ username: "hi" }]);
+
+        script(app, {
+          TOCK_API: true,
+          TOCK_TOKEN: true,
+          ANGRY_TOCK_REPORT_TO: "#test-channel,other-one",
+        });
+
+        const fn = scheduleJob.mock.calls[0][1];
+        await fn();
+
+        expect(postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ channel: "#test-channel" })
+        );
+        expect(postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ channel: "other-one" })
+        );
+      });
+
+      describe("or defaults if unconfigured", () => {
+        it("uses a default if ANGRY_TOCK_TIMEZONE is not set", () => {
+          getCurrentWorkWeek.mockReturnValue([NOW]);
+
+          script(app, {
+            TOCK_API: true,
+            TOCK_TOKEN: true,
+            ANGRY_TOCK_SECOND_TIME: "13:00",
+          });
+
+          const expected = moment.tz("2022-11-14T13:00:00", "America/New_York");
+
+          expect(scheduleJob).toHaveBeenCalledWith(
+            expected.toDate(),
+            expect.any(Function)
+          );
+        });
+
+        it("uses a default if honors ANGRY_TOCK_SECOND_TIME is not set", () => {
+          getCurrentWorkWeek.mockReturnValue([NOW]);
+
+          script(app, {
+            TOCK_API: true,
+            TOCK_TOKEN: true,
+            ANGRY_TOCK_TIMEZONE: "America/Los_Angeles",
+          });
+
+          const expected = moment.tz(
+            "2022-11-14T16:00:00",
+            "America/Los_Angeles"
+          );
+
+          expect(scheduleJob).toHaveBeenCalledWith(
+            expected.toDate(),
+            expect.any(Function)
+          );
+        });
+
+        it("uses a default if honors ANGRY_TOCK_REPORT_TO is not set", async () => {
+          getCurrentWorkWeek.mockReturnValue([NOW]);
+          get18FTockTruants.mockReturnValue([{ username: "hi" }]);
+
+          script(app, {
+            TOCK_API: true,
+            TOCK_TOKEN: true,
+          });
+
+          const fn = scheduleJob.mock.calls[0][1];
+          await fn();
+
+          expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ channel: "#18f-supes" })
+          );
+        });
+      });
+    });
+
+    describe("the report scheduler", () => {
+      const CONFIG = { TOCK_API: "api", TOCK_TOKEN: "token" };
+
+      describe("if the current time is before the next reporting time", () => {
+        it("schedules a report for later today", () => {
+          const NOW = moment
+            .tz("2022-11-14T12:00:00", "America/New_York")
+            .toDate();
+          getCurrentWorkWeek.mockReturnValue([NOW]);
+
+          script(app, CONFIG);
+
+          const expected = moment.tz("2022-11-14T16:00:00", "America/New_York");
+
+          expect(scheduleJob).toHaveBeenCalledWith(
+            expected.toDate(),
+            expect.any(Function)
+          );
+        });
+      });
+
+      describe("if the current time is after the next reporting time", () => {
+        describe("and the next Monday is not a holiday", () => {
+          it("schedules a report for the expected time", () => {
+            const NOW = moment.tz("2022-11-14T12:00:00", "America/New_York");
+            getCurrentWorkWeek.mockReturnValue([NOW.toDate()]);
+
+            jest.setSystemTime(NOW.add(2, "days").toDate());
+
+            script(app, CONFIG);
+
+            const expected = moment.tz(
+              "2022-11-21T16:00:00",
+              "America/New_York"
+            );
+
+            expect(scheduleJob).toHaveBeenCalledWith(
+              expected.toDate(),
+              expect.any(Function)
+            );
+          });
+        });
+        describe("and the next Monday is a holiday", () => {
+          it("schedules a report for the expected time", () => {
+            const NOW = moment.tz("2022-10-03T12:00:00", "America/New_York");
+            getCurrentWorkWeek.mockReturnValue([NOW.toDate()]);
+
+            jest.setSystemTime(NOW.add(2, "days").toDate());
+
+            script(app, CONFIG);
+
+            const expected = moment.tz(
+              "2022-10-11T16:00:00",
+              "America/New_York"
+            );
+
+            expect(scheduleJob).toHaveBeenCalledWith(
+              expected.toDate(),
+              expect.any(Function)
+            );
+          });
+        });
+      });
+    });
+  });
+
+  describe("sends reports", () => {
+    let reportFn;
+
+    beforeAll(() => {
+      script(app, { TOCK_API: "api", TOCK_TOKEN: "token" });
+      reportFn = scheduleJob.mock.calls[0][1];
+    });
+
+    describe("when there are no truants", () => {
+      beforeEach(() => {
+        get18FTockTruants.mockResolvedValue([]);
+      });
+
+      it("does not send a report", async () => {
+        await reportFn();
+
+        expect(postMessage).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when there are some truants", () => {
+      beforeEach(() => {
+        get18FTockTruants.mockResolvedValue([
+          { username: "alice" },
+          { username: "bob" },
+        ]);
+      });
+
+      it("does not send a report", async () => {
+        await reportFn();
+
+        expect(postMessage).toHaveBeenCalledWith({
+          attachments: [
+            {
+              color: "#FF0000",
+              fallback: "• alice\n• bob",
+              text: "• alice\n• bob",
+            },
+          ],
+          channel: "#18f-supes",
+          icon_emoji: ":angrytock:",
+          text: "*The following users are currently truant on Tock:*",
+          username: "Angry Tock",
+        });
+      });
+    });
+  });
+});
+
+/*
+
+REPORTER TESTS:
+===============
+- when there are no truants
+- when there are some truants
+
+*/

--- a/src/utils/cache.test.js
+++ b/src/utils/cache.test.js
@@ -22,8 +22,8 @@ describe("utils / cache", () => {
   // where the clock has ticked some and then stuff gets added to the cache
   // so that it doesn't expire on the next auto-clean. That is correct
   // behavior, but it's hard to account for. Having this test first moots it.
-  it("clears itself of things that are more than 20 minutes old", async () => {
-    const TWENTY_MINUTES = 20 * 60 * 1000;
+  it("clears itself of things that are more than 4 hours old", async () => {
+    const FOUR_HOURS = 4 * 60 * 60 * 1000;
 
     const callback = jest.fn().mockResolvedValue("");
 
@@ -39,7 +39,7 @@ describe("utils / cache", () => {
     expect(callback).not.toHaveBeenCalled();
 
     // Zoom to the future!
-    await jest.advanceTimersByTime(TWENTY_MINUTES);
+    await jest.advanceTimersByTime(FOUR_HOURS);
 
     await cache("key", 300, callback);
     expect(callback).toHaveBeenCalled();

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -70,4 +70,28 @@ const getNextElectionDay = () => {
   return election;
 };
 
-module.exports = { getNextHoliday, getNextElectionDay };
+const getCurrentWorkWeek = () => {
+  // Start with Monday of the current week, and then walk forward if there are
+  // holidays to contend with. Zoom forward to ~midnight.
+  const start = moment
+    .utc() /* .hour(23).minute(59).second(59) */
+    .day(1);
+  while (holidays.isAHoliday(start.toDate(), { utc: true })) {
+    start.add(1, "day");
+  }
+
+  // Now add all of the rest of the working days this week. Loop until we hit
+  // Saturday, and skip any days that are holidays.
+  const days = [start];
+  let next = start.clone().add(1, "day");
+  do {
+    if (!holidays.isAHoliday(next.toDate(), { utc: true })) {
+      days.push(next);
+    }
+    next = next.clone().add(1, "day");
+  } while (next.day() < 6);
+
+  return days.map((date) => date.toDate());
+};
+
+module.exports = { getCurrentWorkWeek, getNextHoliday, getNextElectionDay };

--- a/src/utils/dates.test.js
+++ b/src/utils/dates.test.js
@@ -1,59 +1,9 @@
 const moment = require("moment-timezone");
-const { getNextElectionDay, getNextHoliday } = require("./dates");
-
-describe("gets the next holiday", () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
-  it("defaults to America/New_York time", async () => {
-    // Midnight on May 28 in eastern timezone
-    jest.setSystemTime(
-      +moment.tz("2012-05-28", "YYYY-MM-DD", "America/New_York").format("x")
-    );
-
-    const nextHoliday = getNextHoliday();
-
-    expect(moment(nextHoliday.date).isValid()).toBe(true);
-
-    // remove this from the object match, otherwise
-    // it becomes a whole big thing, dependent on
-    // moment not changing its internal object structure
-    delete nextHoliday.date;
-
-    expect(nextHoliday).toEqual({
-      name: "Independence Day",
-      dateString: "2012-07-04",
-    });
-  });
-
-  it("respects the configured timezone", async () => {
-    // Midnight on May 28 in US eastern timezone.  Because our reminder
-    // timezone is US central timezone, "now" is still May 27, so the
-    // "next" holiday should be May 28 - Memorial Day
-    jest.setSystemTime(
-      +moment.tz("2012-05-28", "YYYY-MM-DD", "America/New_York").format("x")
-    );
-
-    const nextHoliday = getNextHoliday("America/Chicago");
-
-    expect(moment(nextHoliday.date).isValid()).toBe(true);
-
-    // remove this from the object match, otherwise
-    // it becomes a whole big thing, dependent on
-    // moment not changing its internal object structure
-    delete nextHoliday.date;
-
-    expect(nextHoliday).toEqual({
-      name: "Memorial Day",
-      dateString: "2012-05-28",
-    });
-  });
-});
+const {
+  getCurrentWorkWeek,
+  getNextElectionDay,
+  getNextHoliday,
+} = require("./dates");
 
 describe("date utility library", () => {
   beforeAll(() => {
@@ -62,6 +12,52 @@ describe("date utility library", () => {
 
   afterAll(() => {
     jest.useRealTimers();
+  });
+
+  describe("gets the next holiday", () => {
+    it("defaults to America/New_York time", async () => {
+      // Midnight on May 28 in eastern timezone
+      jest.setSystemTime(
+        +moment.tz("2012-05-28", "YYYY-MM-DD", "America/New_York").format("x")
+      );
+
+      const nextHoliday = getNextHoliday();
+
+      expect(moment(nextHoliday.date).isValid()).toBe(true);
+
+      // remove this from the object match, otherwise
+      // it becomes a whole big thing, dependent on
+      // moment not changing its internal object structure
+      delete nextHoliday.date;
+
+      expect(nextHoliday).toEqual({
+        name: "Independence Day",
+        dateString: "2012-07-04",
+      });
+    });
+
+    it("respects the configured timezone", async () => {
+      // Midnight on May 28 in US eastern timezone.  Because our reminder
+      // timezone is US central timezone, "now" is still May 27, so the
+      // "next" holiday should be May 28 - Memorial Day
+      jest.setSystemTime(
+        +moment.tz("2012-05-28", "YYYY-MM-DD", "America/New_York").format("x")
+      );
+
+      const nextHoliday = getNextHoliday("America/Chicago");
+
+      expect(moment(nextHoliday.date).isValid()).toBe(true);
+
+      // remove this from the object match, otherwise
+      // it becomes a whole big thing, dependent on
+      // moment not changing its internal object structure
+      delete nextHoliday.date;
+
+      expect(nextHoliday).toEqual({
+        name: "Memorial Day",
+        dateString: "2012-05-28",
+      });
+    });
   });
 
   describe("gets the next federal election day", () => {
@@ -97,6 +93,93 @@ describe("date utility library", () => {
       const electionDay = getNextElectionDay();
 
       expect(electionDay.isSame(moment.utc("2022-11-08"))).toBe(true);
+    });
+  });
+
+  describe("gets the current working week, accounting for holidays", () => {
+    it("correctly handles a week with no holidays", () => {
+      // Non-holiday week
+      jest.setSystemTime(
+        +moment.tz("2022-11-17", "America/New_York").format("x")
+      );
+
+      const expected = [
+        moment.tz("2022-11-14", "America/New_York"),
+        moment.tz("2022-11-15", "America/New_York"),
+        moment.tz("2022-11-16", "America/New_York"),
+        moment.tz("2022-11-17", "America/New_York"),
+        moment.tz("2022-11-18", "America/New_York"),
+      ];
+
+      const dates = getCurrentWorkWeek();
+
+      expect(dates.length).toBe(expected.length);
+      for (let i = 0; i < expected.length; i += 1) {
+        expect(expected[i].isSame(dates[i], "day")).toBe(true);
+      }
+    });
+
+    it("correctly handles a week with a Monday holiday", () => {
+      // Christmas 2022, falls on a Sunday, but is observed on Monday
+      jest.setSystemTime(
+        +moment.tz("2022-12-26", "America/New_York").format("x")
+      );
+
+      const expected = [
+        moment.tz("2022-12-27", "America/New_York"),
+        moment.tz("2022-12-28", "America/New_York"),
+        moment.tz("2022-12-29", "America/New_York"),
+        moment.tz("2022-12-30", "America/New_York"),
+      ];
+
+      const dates = getCurrentWorkWeek();
+
+      expect(dates.length).toBe(expected.length);
+      for (let i = 0; i < expected.length; i += 1) {
+        expect(expected[i].isSame(dates[i], "day")).toBe(true);
+      }
+    });
+
+    it("correctly handles a week with a Friday holiday", () => {
+      // Veterans Day 2022, falls on a Friday
+      jest.setSystemTime(
+        +moment.tz("2022-11-08", "America/New_York").format("x")
+      );
+
+      const expected = [
+        moment.tz("2022-11-07", "America/New_York"),
+        moment.tz("2022-11-08", "America/New_York"),
+        moment.tz("2022-11-09", "America/New_York"),
+        moment.tz("2022-11-10", "America/New_York"),
+      ];
+
+      const dates = getCurrentWorkWeek();
+
+      expect(dates.length).toBe(expected.length);
+      for (let i = 0; i < expected.length; i += 1) {
+        expect(expected[i].isSame(dates[i], "day")).toBe(true);
+      }
+    });
+
+    it("correctly handles a week with a midweek holiday", () => {
+      // Thanksgiving 2022, falls on a Thursday
+      jest.setSystemTime(
+        +moment.tz("2022-11-24", "America/New_York").format("x")
+      );
+
+      const expected = [
+        moment.tz("2022-11-21", "America/New_York"),
+        moment.tz("2022-11-22", "America/New_York"),
+        moment.tz("2022-11-23", "America/New_York"),
+        moment.tz("2022-11-25", "America/New_York"),
+      ];
+
+      const dates = getCurrentWorkWeek();
+
+      expect(dates.length).toBe(expected.length);
+      for (let i = 0; i < expected.length; i += 1) {
+        expect(expected[i].isSame(dates[i], "day")).toBe(true);
+      }
     });
   });
 });


### PR DESCRIPTION
- adds a new date utility for getting the days of the current working week (and leaves out days that are holidays)
- removes ops report from Angry Tock
- updates Angry Tock to use date utility to schedule its shouting matches
- adds a new script for ops reporting
- adds a GitHub action that detects changes to the new ops reporting script and reminds PR authors to collaborate with the 18F director of operations
- closes #480 

---

Checklist:

- [x] Code has been formatted with prettier
- [x] N/A ~The [OAuth](https://github.com/18F/charlie/wiki/OAuthEventsAndScopes) wiki
      page has been updated if Charlie needs any new OAuth events or scopes~
- [x] The [Environment Variables](https://github.com/18F/charlie/wiki/EnvironmentVariables)
      wiki page has been updated if new environment variables were introduced
      or existing ones changed
- [x] The dev wiki has been updated, e.g.:
  - local development processes have changed
  - major development workflows have changed
  - internal utilities or APIs have changed
  - testing or deployment processes have changed
- [x] N/A ~If appropriate, the NIST 800-218 documentation has been updated~
