### PR TITLE
Update the work week utility to be more reliable

### DIFF
--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -72,10 +72,8 @@ const getNextElectionDay = () => {
 
 const getCurrentWorkWeek = () => {
   // Start with Monday of the current week, and then walk forward if there are
-  // holidays to contend with. Zoom forward to ~midnight.
-  const start = moment
-    .utc() /* .hour(23).minute(59).second(59) */
-    .day(1);
+  // holidays to contend with.
+  const start = moment.utc().day(1);
   while (holidays.isAHoliday(start.toDate(), { utc: true })) {
     start.add(1, "day");
   }
@@ -91,7 +89,8 @@ const getCurrentWorkWeek = () => {
     next = next.clone().add(1, "day");
   } while (next.day() < 6);
 
-  return days.map((date) => date.toDate());
+  // Return just the date string. Eliminate the time portion.
+  return days.map((date) => date.format("YYYY-MM-DD"));
 };
 
 module.exports = { getCurrentWorkWeek, getNextHoliday, getNextElectionDay };

--- a/src/utils/dates.test.js
+++ b/src/utils/dates.test.js
@@ -103,20 +103,15 @@ describe("date utility library", () => {
         +moment.tz("2022-11-17", "America/New_York").format("x")
       );
 
-      const expected = [
-        moment.tz("2022-11-14", "America/New_York"),
-        moment.tz("2022-11-15", "America/New_York"),
-        moment.tz("2022-11-16", "America/New_York"),
-        moment.tz("2022-11-17", "America/New_York"),
-        moment.tz("2022-11-18", "America/New_York"),
-      ];
-
       const dates = getCurrentWorkWeek();
 
-      expect(dates.length).toBe(expected.length);
-      for (let i = 0; i < expected.length; i += 1) {
-        expect(expected[i].isSame(dates[i], "day")).toBe(true);
-      }
+      expect(dates).toEqual([
+        "2022-11-14",
+        "2022-11-15",
+        "2022-11-16",
+        "2022-11-17",
+        "2022-11-18",
+      ]);
     });
 
     it("correctly handles a week with a Monday holiday", () => {
@@ -125,19 +120,14 @@ describe("date utility library", () => {
         +moment.tz("2022-12-26", "America/New_York").format("x")
       );
 
-      const expected = [
-        moment.tz("2022-12-27", "America/New_York"),
-        moment.tz("2022-12-28", "America/New_York"),
-        moment.tz("2022-12-29", "America/New_York"),
-        moment.tz("2022-12-30", "America/New_York"),
-      ];
-
       const dates = getCurrentWorkWeek();
 
-      expect(dates.length).toBe(expected.length);
-      for (let i = 0; i < expected.length; i += 1) {
-        expect(expected[i].isSame(dates[i], "day")).toBe(true);
-      }
+      expect(dates).toEqual([
+        "2022-12-27",
+        "2022-12-28",
+        "2022-12-29",
+        "2022-12-30",
+      ]);
     });
 
     it("correctly handles a week with a Friday holiday", () => {
@@ -146,19 +136,14 @@ describe("date utility library", () => {
         +moment.tz("2022-11-08", "America/New_York").format("x")
       );
 
-      const expected = [
-        moment.tz("2022-11-07", "America/New_York"),
-        moment.tz("2022-11-08", "America/New_York"),
-        moment.tz("2022-11-09", "America/New_York"),
-        moment.tz("2022-11-10", "America/New_York"),
-      ];
-
       const dates = getCurrentWorkWeek();
 
-      expect(dates.length).toBe(expected.length);
-      for (let i = 0; i < expected.length; i += 1) {
-        expect(expected[i].isSame(dates[i], "day")).toBe(true);
-      }
+      expect(dates).toEqual([
+        "2022-11-07",
+        "2022-11-08",
+        "2022-11-09",
+        "2022-11-10",
+      ]);
     });
 
     it("correctly handles a week with a midweek holiday", () => {
@@ -167,19 +152,14 @@ describe("date utility library", () => {
         +moment.tz("2022-11-24", "America/New_York").format("x")
       );
 
-      const expected = [
-        moment.tz("2022-11-21", "America/New_York"),
-        moment.tz("2022-11-22", "America/New_York"),
-        moment.tz("2022-11-23", "America/New_York"),
-        moment.tz("2022-11-25", "America/New_York"),
-      ];
-
       const dates = getCurrentWorkWeek();
 
-      expect(dates.length).toBe(expected.length);
-      for (let i = 0; i < expected.length; i += 1) {
-        expect(expected[i].isSame(dates[i], "day")).toBe(true);
-      }
+      expect(dates).toEqual([
+        "2022-11-21",
+        "2022-11-22",
+        "2022-11-23",
+        "2022-11-25",
+      ]);
     });
   });
 });


### PR DESCRIPTION
The date utility helper `getCurrentWorkWeek` currently returns a list of `Date` objects. These objects include a UTC timestamp, which can cause issues when transforming into the reporting timezone. Rather than dealing with that, this PR opts to return a date string of the form `YYYY-MM-DD` and let utility consumers decide what to do with that. Happily, using the Moment.js timezone-aware factory with a date string works as expected, creating an object whose time component is midnight in the specified timezone. And also happily, the parts of Charlie that current using `getCurrentWorkWeek` also use that factory method.

This is intended to fix a bug where some timed events would actually happen a day earlier than expected. For example, Angry Tock's first "shout."

---

Checklist:

- [x] Code has been formatted with prettier
- [ ] The dev wiki has been updated, e.g.:
  - internal utilities or APIs have changed