### PR TITLE
Bug fix: Use a case-insensitive comparison between Tock and Slack email addresses

### DIFF
--- a/src/scripts/angry-tock.js
+++ b/src/scripts/angry-tock.js
@@ -46,7 +46,9 @@ module.exports = (app, config = process.env) => {
     const tockSlackUsers = await get18FTockSlackUsers();
     const truants = await get18FTockTruants(moment.tz(ANGRY_TOCK_TIMEZONE));
     const slackableTruants = tockSlackUsers.filter((tockUser) =>
-      truants.some((truant) => truant.email === tockUser.email)
+      truants.some(
+        (truant) => truant.email.toLowerCase() === tockUser.email.toLowerCase()
+      )
     );
 
     slackableTruants.forEach(({ slack_id: slackID }) => {

--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -63,7 +63,7 @@ describe("Angry Tock", () => {
 
     get18FTockSlackUsers.mockResolvedValue([
       {
-        email: "user@one",
+        email: "UsEr@one",
         id: "tock1",
         name: "User 1",
         slack_id: "slack1",

--- a/src/scripts/optimistic-tock.js
+++ b/src/scripts/optimistic-tock.js
@@ -56,7 +56,11 @@ module.exports = async (app, config = process.env) => {
 
     const truantTockSlackUsers = tockSlackUsers
       .filter((tockUser) => tockUser.tz === tz)
-      .filter((tockUser) => truants.some((t) => t.email === tockUser.email))
+      .filter((tockUser) =>
+        truants.some(
+          (t) => t.email.toLowerCase() === tockUser.email.toLowerCase()
+        )
+      )
       .filter((tockUser) => !optout.isOptedOut(tockUser.slack_id));
 
     await Promise.all(

--- a/src/scripts/optimistic-tock.test.js
+++ b/src/scripts/optimistic-tock.test.js
@@ -52,7 +52,7 @@ describe("Optimistic Tock", () => {
 
     get18FTockSlackUsers.mockResolvedValue([
       {
-        email: "user@one",
+        email: "UsEr@one",
         id: "tock1",
         name: "User 1",
         slack_id: "slack 1",

--- a/src/utils/tock.js
+++ b/src/utils/tock.js
@@ -100,11 +100,17 @@ const get18FTockSlackUsers = async () => {
 
   const tockSlackUsers = tockUsers
     .filter((tock) =>
-      slackUsers.some((slackUser) => slackUser.email === tock.email)
+      slackUsers.some(
+        (slackUser) =>
+          slackUser.email.toLowerCase() === tock.email.toLowerCase()
+      )
     )
     .map((tock) => ({
       ...tock,
-      ...slackUsers.find((slackUser) => slackUser.email === tock.email),
+      ...slackUsers.find(
+        (slackUser) =>
+          slackUser.email.toLowerCase() === tock.email.toLowerCase()
+      ),
     }));
 
   return tockSlackUsers;

--- a/src/utils/tock.test.js
+++ b/src/utils/tock.test.js
@@ -25,7 +25,7 @@ describe("utils / tock", () => {
       id: "slack 1",
       is_bot: false,
       is_restricted: false,
-      profile: { email: "email 1" },
+      profile: { email: "EmAiL 1" },
       real_name: "user 1",
       tz: "timezone 1",
     },
@@ -164,7 +164,9 @@ describe("utils / tock", () => {
 
     expect(users).toEqual([
       {
-        email: "email 1",
+        // Canonical email address is taken from Slack. The Slack mock data has
+        // this email address in mixed caps, so that's what we expect to see.
+        email: "EmAiL 1",
         name: "user 1",
         slack_id: "slack 1",
         tock_id: 1,


### PR DESCRIPTION
Charlie uses email addresses stored in Tock and Slack to correlate a user in one with a user in another. It currently does a case-sensitive comparison, which works in most cases, but at least one person's email address in Slack has capital letters while their email address in Tock does not. They did not receive any Optimistic or Angry Tock reminders as a result.

This PR modifies the tests for Angry Tock, Optimistic Tock, and the Tock utility library to add case mismatches in the mocked data. Those tests promptly failed. This PR then updates those bits of code to do case-insensitive comparisons and make the updated tests pass.

---

Checklist:

- [x] Code has been formatted with prettier
- the rest is N/A