### PR TITLE
Crashing bug: Email addresses from Slack and/or Tock are sometimes empty

### DIFF
--- a/src/scripts/angry-tock.js
+++ b/src/scripts/angry-tock.js
@@ -47,7 +47,8 @@ module.exports = (app, config = process.env) => {
     const truants = await get18FTockTruants(moment.tz(ANGRY_TOCK_TIMEZONE));
     const slackableTruants = tockSlackUsers.filter((tockUser) =>
       truants.some(
-        (truant) => truant.email.toLowerCase() === tockUser.email.toLowerCase()
+        (truant) =>
+          truant.email?.toLowerCase() === tockUser.email?.toLowerCase()
       )
     );
 

--- a/src/scripts/optimistic-tock.js
+++ b/src/scripts/optimistic-tock.js
@@ -58,7 +58,7 @@ module.exports = async (app, config = process.env) => {
       .filter((tockUser) => tockUser.tz === tz)
       .filter((tockUser) =>
         truants.some(
-          (t) => t.email.toLowerCase() === tockUser.email.toLowerCase()
+          (t) => t.email?.toLowerCase() === tockUser.email?.toLowerCase()
         )
       )
       .filter((tockUser) => !optout.isOptedOut(tockUser.slack_id));

--- a/src/utils/tock.js
+++ b/src/utils/tock.js
@@ -102,14 +102,14 @@ const get18FTockSlackUsers = async () => {
     .filter((tock) =>
       slackUsers.some(
         (slackUser) =>
-          slackUser.email.toLowerCase() === tock.email.toLowerCase()
+          slackUser.email?.toLowerCase() === tock.email?.toLowerCase()
       )
     )
     .map((tock) => ({
       ...tock,
       ...slackUsers.find(
         (slackUser) =>
-          slackUser.email.toLowerCase() === tock.email.toLowerCase()
+          slackUser.email?.toLowerCase() === tock.email?.toLowerCase()
       ),
     }));
 


### PR DESCRIPTION
#486 introduced a case-insensitive comparison for emails, but it turns out that emails can sometimes be undefined or null. As a result, Charlie promptly crashes on startup when it's scheduling Tock reminders (these are based on Tockable users' timezones, and email comparison is necessary to figure out which Slack users are Tockable).

This fixes that bug by using optional chaining. If the email is null or undefined, the whole chain will be treated as `undefined` and that's just fine.

---

Checklist:

- [x] Code has been formatted with prettier
- n/a