### PR TITLE
Remove the word "truant"

### DIFF
--- a/.github/workflows/on_pull_request_tock_ops.yml
+++ b/.github/workflows/on_pull_request_tock_ops.yml
@@ -19,5 +19,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "It looks like you're updating the Tock truancy report. Please ensure that the 18F director of operations is aware of these changes because the Tock truancy report is used by the ops team and needs to function."
+              body: "It looks like you're updating the Tock report. Please ensure that the 18F director of operations is aware of these changes because the Tock report is used by the ops team and needs to function."
             });

--- a/.github/workflows/on_pull_request_tock_ops.yml
+++ b/.github/workflows/on_pull_request_tock_ops.yml
@@ -3,8 +3,8 @@ name: tock ops report changes
 on:
   pull_request:
     paths:
-      - src/scripts/tock-truant-ops-report.js
-      - src/scripts/tock-truant-ops-report.test.js
+      - src/scripts/tock-ops-report.js
+      - src/scripts/tock-ops-report.test.js
 
 jobs:
   comment:

--- a/src/scripts/angry-tock.js
+++ b/src/scripts/angry-tock.js
@@ -67,7 +67,7 @@ module.exports = (app, config = process.env) => {
       .minute(ANGRY_TOCK_SECOND_ALERT.minute())
       .second(0);
 
-    // If we've already passed the truancy report time for the current work week,
+    // If we've already passed the report time for the current work week,
     // jump to the next Monday, and then scoot forward over any holidays.
     if (reportTime.isBefore(moment())) {
       reportTime.add(7, "days").day(1);

--- a/src/scripts/angry-tock.test.js
+++ b/src/scripts/angry-tock.test.js
@@ -5,7 +5,7 @@ const {
   utils: {
     dates: { getCurrentWorkWeek },
     slack: { sendDirectMessage },
-    tock: { get18FTockSlackUsers, get18FTockTruants },
+    tock: { get18FTockSlackUsers, get18FUsersWhoHaveNotTocked },
   },
 } = require("../utils/test");
 
@@ -37,7 +37,7 @@ describe("Angry Tock", () => {
     jest.setSystemTime(0);
     jest.resetAllMocks();
 
-    get18FTockTruants.mockResolvedValue([
+    get18FUsersWhoHaveNotTocked.mockResolvedValue([
       {
         id: "tock1",
         email: "user@one",
@@ -217,7 +217,7 @@ describe("Angry Tock", () => {
     });
   });
 
-  it("sends a calm/disappointed message first, then an angry message and truant report", async () => {
+  it("sends a calm/disappointed message first, then an angry message", async () => {
     // Monday, May 1, 1978 - Ernest Nathan Morial, first African-American mayor
     // of New Orleans, is inaugurated.
     const initial = moment.tz(
@@ -277,11 +277,11 @@ describe("Angry Tock", () => {
       text: ":angrytock: <https://tock.18f.gov|Tock your time>! You gotta!",
     });
 
-    // Clear everything out again, and make sure that the "angry" shout turns
-    // very happy if there aren't any truants.
+    // Clear everything out again, and make sure that the "angry" shout doesn't
+    // shout.
     sendDirectMessage.mockClear();
 
-    get18FTockTruants.mockResolvedValue([]);
+    get18FUsersWhoHaveNotTocked.mockResolvedValue([]);
     await angryShout();
 
     expect(sendDirectMessage.mock.calls.length).toBe(0);

--- a/src/scripts/optimistic-tock.test.js
+++ b/src/scripts/optimistic-tock.test.js
@@ -5,7 +5,7 @@ const {
   utils: {
     optOut,
     slack: { sendDirectMessage },
-    tock: { get18FTockSlackUsers, get18FTockTruants },
+    tock: { get18FTockSlackUsers, get18FUsersWhoHaveNotTocked },
   },
 } = require("../utils/test");
 
@@ -33,7 +33,7 @@ describe("Optimistic Tock", () => {
 
     optOut.mockReturnValue({ button: { button: "goes here" }, isOptedOut });
 
-    get18FTockTruants.mockResolvedValue([
+    get18FUsersWhoHaveNotTocked.mockResolvedValue([
       {
         id: "tock1",
         email: "user@one",

--- a/src/scripts/tock-ops-report.js
+++ b/src/scripts/tock-ops-report.js
@@ -35,7 +35,7 @@ module.exports = (app, config = process.env) => {
       .minute(TRUANT_REPORT_TIME.minute())
       .second(0);
 
-    // If we've already passed the truancy report time for the current work week,
+    // If we've already passed the report time for the current work week,
     // jump to the next Monday, and then scoot forward over any holidays.
     if (reportTime.isBefore(moment())) {
       reportTime.add(7, "days").day(1);

--- a/src/scripts/tock-ops-report.test.js
+++ b/src/scripts/tock-ops-report.test.js
@@ -8,7 +8,7 @@ const {
   },
 } = require("../utils/test");
 
-describe("Tock truancy reporter for ops", () => {
+describe("Tock reporter for ops", () => {
   const app = getApp();
 
   const scheduleJob = jest.fn();

--- a/src/scripts/tock-ops-report.test.js
+++ b/src/scripts/tock-ops-report.test.js
@@ -3,7 +3,7 @@ const {
   getApp,
   utils: {
     dates: { getCurrentWorkWeek },
-    tock: { get18FTockTruants },
+    tock: { get18FUsersWhoHaveNotTocked },
     slack: { postMessage },
   },
 } = require("../utils/test");
@@ -109,7 +109,7 @@ describe("Tock truancy reporter for ops", () => {
 
       it("honors ANGRY_TOCK_REPORT_TO", async () => {
         getCurrentWorkWeek.mockReturnValue([NOW]);
-        get18FTockTruants.mockReturnValue([{ username: "hi" }]);
+        get18FUsersWhoHaveNotTocked.mockReturnValue([{ username: "hi" }]);
 
         script(app, {
           TOCK_API: true,
@@ -168,7 +168,7 @@ describe("Tock truancy reporter for ops", () => {
 
         it("uses a default if honors ANGRY_TOCK_REPORT_TO is not set", async () => {
           getCurrentWorkWeek.mockReturnValue([NOW]);
-          get18FTockTruants.mockReturnValue([{ username: "hi" }]);
+          get18FUsersWhoHaveNotTocked.mockReturnValue([{ username: "hi" }]);
 
           script(app, {
             TOCK_API: true,
@@ -260,9 +260,9 @@ describe("Tock truancy reporter for ops", () => {
       reportFn = scheduleJob.mock.calls[0][1];
     });
 
-    describe("when there are no truants", () => {
+    describe("when all users have Tocked", () => {
       beforeEach(() => {
-        get18FTockTruants.mockResolvedValue([]);
+        get18FUsersWhoHaveNotTocked.mockResolvedValue([]);
       });
 
       it("does not send a report", async () => {
@@ -272,9 +272,9 @@ describe("Tock truancy reporter for ops", () => {
       });
     });
 
-    describe("when there are some truants", () => {
+    describe("when some users have not Tocked", () => {
       beforeEach(() => {
-        get18FTockTruants.mockResolvedValue([
+        get18FUsersWhoHaveNotTocked.mockResolvedValue([
           { username: "alice" },
           { username: "bob" },
         ]);
@@ -293,19 +293,10 @@ describe("Tock truancy reporter for ops", () => {
           ],
           channel: "#18f-supes",
           icon_emoji: ":angrytock:",
-          text: "*The following users are currently truant on Tock:*",
+          text: "*The following users have not yet reported their time on Tock:*",
           username: "Angry Tock",
         });
       });
     });
   });
 });
-
-/*
-
-REPORTER TESTS:
-===============
-- when there are no truants
-- when there are some truants
-
-*/

--- a/src/scripts/tock-ops-report.test.js
+++ b/src/scripts/tock-ops-report.test.js
@@ -17,7 +17,7 @@ describe("Tock truancy reporter for ops", () => {
   // Load this module *after* everything gets mocked. Otherwise the module will
   // load the unmocked stuff and the tests won't work.
   // eslint-disable-next-line global-require
-  const script = require("./tock-truant-ops-report");
+  const script = require("./tock-ops-report");
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/src/utils/tock.js
+++ b/src/utils/tock.js
@@ -48,14 +48,14 @@ const getCurrent18FTockUsers = async () => {
 };
 
 /**
- * Get the 18F truant users for the most recent completed Tock reporting
+ * Get the 18F users who have not recorded their time in Tock for a given time
  * period.
  * @async
  * @param {Object} now Moment object representing the current time.
  * @param {Number} weeksAgo How many weeks in the past to check. Defaults to 1.
- * @returns {<Promise<Array<Object>>} The list of truant users
+ * @returns {<Promise<Array<Object>>} The list of users who have not Tocked
  */
-const get18FTockTruants = async (now, weeksAgo = 1) => {
+const get18FUsersWhoHaveNotTocked = async (now, weeksAgo = 1) => {
   while (now.format("dddd") !== "Sunday") {
     now.subtract(1, "day");
   }
@@ -67,12 +67,12 @@ const get18FTockTruants = async (now, weeksAgo = 1) => {
 
   const tockUsers = await getCurrent18FTockUsers();
 
-  const allTruants = await getFromTock(
+  const allUnreportedUsers = await getFromTock(
     `/reporting_period_audit/${reportingPeriodStart}.json`
   );
 
-  return allTruants.filter((truant) =>
-    tockUsers.some((tockUser) => tockUser.tock_id === truant.id)
+  return allUnreportedUsers.filter((user) =>
+    tockUsers.some((tockUser) => tockUser.tock_id === user.id)
   );
 };
 
@@ -118,6 +118,6 @@ const get18FTockSlackUsers = async () => {
 
 module.exports = {
   getCurrent18FTockUsers,
-  get18FTockTruants,
+  get18FUsersWhoHaveNotTocked,
   get18FTockSlackUsers,
 };

--- a/src/utils/tock.js
+++ b/src/utils/tock.js
@@ -67,11 +67,11 @@ const get18FUsersWhoHaveNotTocked = async (now, weeksAgo = 1) => {
 
   const tockUsers = await getCurrent18FTockUsers();
 
-  const allUnreportedUsers = await getFromTock(
+  const allUnTockedUsers = await getFromTock(
     `/reporting_period_audit/${reportingPeriodStart}.json`
   );
 
-  return allUnreportedUsers.filter((user) =>
+  return allUnTockedUsers.filter((user) =>
     tockUsers.some((tockUser) => tockUser.tock_id === user.id)
   );
 };

--- a/src/utils/tock.test.js
+++ b/src/utils/tock.test.js
@@ -15,7 +15,7 @@ describe("utils / tock", () => {
 
   const {
     get18FTockSlackUsers,
-    get18FTockTruants,
+    get18FUsersWhoHaveNotTocked,
     getCurrent18FTockUsers,
   } = require("./tock"); // eslint-disable-line global-require
 
@@ -184,7 +184,7 @@ describe("utils / tock", () => {
     ]);
   });
 
-  describe("gets a list of 18F Tock users who are truant", () => {
+  describe("gets a list of 18F Tock users who have not Tocked", () => {
     beforeAll(() => {
       jest.useFakeTimers();
     });
@@ -200,23 +200,19 @@ describe("utils / tock", () => {
     it("defaults to looking at the reporting period from a week ago", async () => {
       const date = moment("2020-10-14");
       jest.setSystemTime(date.toDate());
-      const truants = await get18FTockTruants(date);
+      const users = await get18FUsersWhoHaveNotTocked(date);
 
-      // Only user 1 is truant from the previous period.
-      expect(truants).toEqual([
-        { id: 1, email: "email 1", username: "user 1" },
-      ]);
+      // Only user 1 has not reported in the previous period.
+      expect(users).toEqual([{ id: 1, email: "email 1", username: "user 1" }]);
     });
 
     it("defaults to looking at the reporting period from this week", async () => {
       const date = moment("2020-10-14");
       jest.setSystemTime(date.toDate());
-      const truants = await get18FTockTruants(date, 0);
+      const users = await get18FUsersWhoHaveNotTocked(date, 0);
 
-      // Only user 5 is truant in the current period.
-      expect(truants).toEqual([
-        { id: 5, email: "email 5", username: "user 5" },
-      ]);
+      // Only user 5 has not reported in the current period.
+      expect(users).toEqual([{ id: 5, email: "email 5", username: "user 5" }]);
     });
   });
 });


### PR DESCRIPTION
#492 describes how the word "truant" has *not great* implications, and we might want to avoid those. This PR removes the word "truant" in most of the code and, most importantly, from user-facing messages. A future issue would be to rename the environment variables that configure the Tock ops report as well.

Closes #492

---

Checklist:

- [x] Code has been formatted with prettier
- [x] The dev wiki has been updated, e.g.:
  - local development processes have changed
  - major development workflows have changed
  - internal utilities or APIs have changed
  - testing or deployment processes have changed