### PR TITLE
Fix a bug with the thing that creates releases on publish to main

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: ./node_modules


### PR DESCRIPTION
The thing is referencing a version of the GitHub checkout action that does not exist. This PR updates that thing to reference a version that does exist.