### PR TITLE
Fix dev deploy

### DIFF
--- a/.github/workflows/reusable_deploy.yml
+++ b/.github/workflows/reusable_deploy.yml
@@ -43,7 +43,7 @@ jobs:
           do
             echo "Waiting for database service to be ready..."
             sleep 10
-            $STATUS=$(cf service charlie-brain | grep "  status:" | awk -F ":" '{print $2}' | xargs)
+            STATUS="$(cf service charlie-brain | grep "  status:" | awk -F ":" '{print $2}' | xargs echo)"
           done
       - name: push to cloud.gov
         env:

--- a/.github/workflows/reusable_deploy.yml
+++ b/.github/workflows/reusable_deploy.yml
@@ -29,7 +29,22 @@ jobs:
       - name: add extra deployment steps for dev
         id: devSteps
         if: ${{ inputs.environment == 'dev' }}
-        run: echo 'command="cf create-service aws-rds micro-psql charlie-brain; bash .github/workflows/wait-for-database.sh"' >> "$GITHUB_OUTPUT"
+        env:
+          CF_API: ${{ secrets.CF_API }}
+          CF_ORG: ${{ secrets.CF_ORG }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+          CF_SPACE: ${{ inputs.environment }}
+          CF_USERNAME: ${{ secrets.CF_USERNAME }}
+        run: |
+          cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+          cf create-service aws-rds micro-psql charlie-brain
+          STATUS="$(cf service charlie-brain | grep "  status:" | awk -F ":" '{print $2}' | xargs)"
+          while [ "$STATUS"  != "create succeeded" ]
+          do
+            echo "Waiting for database service to be ready..."
+            sleep 10
+            $STATUS=$(cf service charlie-brain | grep "  status:" | awk -F ":" '{print $2}' | xargs)
+          done
       - name: push to cloud.gov
         env:
           CF_API: ${{ secrets.CF_API }}
@@ -39,5 +54,4 @@ jobs:
           CF_USERNAME: ${{ secrets.CF_USERNAME }}
         run: |
           cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
-          ${{ steps.devSteps.outputs.command }}
           cf push -f manifest.yml --vars-file ./${{ inputs.environment }}.yml

--- a/.github/workflows/wait-for-database.sh
+++ b/.github/workflows/wait-for-database.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-STATUS="$(cf service charlie-brain | grep "  status:" | awk -F ":" '{print $2}' | xargs)"
-while [ "$STATUS"  != "create succeeded" ]
-do
-  echo "Waiting for database service to be ready..."
-  sleep 10
-  $STATUS=$(cf service charlie-brain | grep "  status:" | awk -F ":" '{print $2}' | xargs)
-done

--- a/src/brain.js
+++ b/src/brain.js
@@ -14,7 +14,7 @@ const set = async (key, value) => {
 };
 
 const initialize = async (config = process.env) => {
-  client = new Client({ connectionString: config.DATABASE_URL });
+  client = new Client({ connectionString: config.DATABASE_URL, ssl: true });
   await client.connect();
 
   await client.query(


### PR DESCRIPTION
The dev deploy creates a database if one does not already exist. This is because the dev database is automatically removed nightly to keep cloud.gov costs down. However, the action for deploying didn't work correctly. The code for waiting until the database was ready was broken. Furthermore, new Postgres databases require an SSL connection, which our client wasn't offering. This PR fixes both things.

---

Checklist:

- [x] Code has been formatted with prettier
- N/A ~The [OAuth](https://github.com/18F/charlie/wiki/OAuthEventsAndScopes) wiki page has been updated if Charlie needs any new OAuth events or scopes~
- N/A ~The [Environment Variables](https://github.com/18F/charlie/wiki/EnvironmentVariables) page has been updated if new environment variables were introduced or existing ones changed~
- N/A ~The dev wiki has been updated~
- N/A ~If appropriate, the NIST 800-218 documentation has been updated~
