### PR TITLE
Random default emoji!

### DIFF
--- a/src/scripts/random-responses.js
+++ b/src/scripts/random-responses.js
@@ -94,8 +94,16 @@ const responseFrom =
     ) ?? [false, false, false, false];
 
     const message = { thread_ts: thread, unfurl_links: false };
+
     if (defaultEmoji) {
-      message.icon_emoji = defaultEmoji;
+      // The default emoji defined by the config may be a single emoji or a list.
+      // If it's a list, pick one at random.
+      if (Array.isArray(defaultEmoji)) {
+        message.icon_emoji =
+          defaultEmoji[Math.floor(Math.random() * defaultEmoji.length)];
+      } else {
+        message.icon_emoji = defaultEmoji;
+      }
     }
     if (botName) {
       message.username = botName;

--- a/src/scripts/random-responses.js
+++ b/src/scripts/random-responses.js
@@ -99,8 +99,10 @@ const responseFrom =
       // The default emoji defined by the config may be a single emoji or a list.
       // If it's a list, pick one at random.
       if (Array.isArray(defaultEmoji)) {
-        message.icon_emoji =
-          defaultEmoji[Math.floor(Math.random() * defaultEmoji.length)];
+        if (defaultEmoji.length > 0) {
+          message.icon_emoji =
+            defaultEmoji[Math.floor(Math.random() * defaultEmoji.length)];
+        }
       } else {
         message.icon_emoji = defaultEmoji;
       }

--- a/src/scripts/random-responses.test.js
+++ b/src/scripts/random-responses.test.js
@@ -110,19 +110,49 @@ describe("random responder", () => {
     });
 
     describe("with default emoji set", () => {
-      const baseExpectation = { icon_emoji: ":default-emoji:" };
+      describe("as a single emoji", () => {
+        const baseExpectation = { icon_emoji: ":default-emoji:" };
 
-      responsePermutations.forEach(({ testName, responseList, expected }) => {
-        it(testName, async () => {
-          config.defaultEmoji = ":default-emoji:";
-          random.mockReturnValue(0);
+        responsePermutations.forEach(({ testName, responseList, expected }) => {
+          it(testName, async () => {
+            config.defaultEmoji = ":default-emoji:";
+            random.mockReturnValue(0);
 
-          await script.responseFrom({ ...config, responseList })(message);
+            await script.responseFrom({ ...config, responseList })(message);
 
-          expect(random).toHaveBeenCalled();
-          expect(message.say).toHaveBeenCalledWith({
-            ...baseExpectation,
-            ...expected,
+            expect(random).toHaveBeenCalled();
+            expect(message.say).toHaveBeenCalledWith({
+              ...baseExpectation,
+              ...expected,
+            });
+          });
+        });
+      });
+
+      describe("as a list of random emoji", () => {
+        afterAll(() => {
+          config.defaultEmoji = null;
+        });
+
+        responsePermutations.forEach(({ testName, responseList, expected }) => {
+          it(testName, async () => {
+            config.defaultEmoji = [
+              ":default-emoji-1:",
+              ":default-emoji-2:",
+              ":default-emoji-3:",
+              ":default-emoji-4:",
+              ":default-emoji-5:",
+            ];
+            random
+              .mockReturnValueOnce(3 / 5)
+              .mockReturnValueOnce(0)
+              .mockReturnValueOnce(0);
+            await script.responseFrom({ ...config, responseList })(message);
+
+            expect(message.say).toHaveBeenCalledWith({
+              icon_emoji: config.defaultEmoji[3],
+              ...expected,
+            });
           });
         });
       });

--- a/src/scripts/random-responses.test.js
+++ b/src/scripts/random-responses.test.js
@@ -134,6 +134,19 @@ describe("random responder", () => {
           config.defaultEmoji = null;
         });
 
+        it("and the list of emoji is empty", async () => {
+          config.defaultEmoji = [];
+          random
+            .mockReturnValueOnce(3 / 5)
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(0);
+
+          const { responseList, expected } = responsePermutations[0];
+          await script.responseFrom({ ...config, responseList })(message);
+
+          expect(message.say).toHaveBeenCalledWith(expected);
+        });
+
         responsePermutations.forEach(({ testName, responseList, expected }) => {
           it(testName, async () => {
             config.defaultEmoji = [


### PR DESCRIPTION
It would be super neat if our random responses could define a random emoji to be used when posting them. This PR makes that so. Screambot will be in for such a delightful update.

---

Checklist:

- [X] Code has been formatted with prettier
- ~The [OAuth](https://github.com/18F/charlie/wiki/OAuthEventsAndScopes) wiki
      page has been updated if Charlie needs any new OAuth events or scopes~
- ~The [Environment Variables](https://github.com/18F/charlie/wiki/EnvironmentVariables)
      wiki page has been updated if new environment variables were introduced
      or existing ones changed~
- The dev wiki has been updated, e.g.:
  - local development processes have changed
  - ~major development workflows have changed~
  - ~internal utilities or APIs have changed~
  - ~testing or deployment processes have changed~
- ~If appropriate, the NIST 800-218 documentation has been updated~
