### PR TITLE
Remove @here notifications

### DIFF
--- a/src/scripts/federal-holidays-reminder.js
+++ b/src/scripts/federal-holidays-reminder.js
@@ -51,7 +51,7 @@ const scheduleReminder = (_, config = process.env) => {
 
     await postMessage({
       channel: CHANNEL,
-      text: `<!here> Remember that *${holiday.date.format(
+      text: `Remember that *${holiday.date.format(
         "dddd",
       )}* is a federal holiday in observance of *${
         holiday.alsoObservedAs ?? holiday.name

--- a/src/scripts/federal-holidays-reminder.test.js
+++ b/src/scripts/federal-holidays-reminder.test.js
@@ -104,7 +104,7 @@ describe("holiday reminder", () => {
       expect(postMessage).toHaveBeenCalledWith({
         channel: "general",
         text: expect.stringMatching(
-          /^<!here> Remember that \*Thursday\* is a federal holiday in observance of \*test holiday\*! .+$/,
+          /^Remember that \*Thursday\* is a federal holiday in observance of \*test holiday\*! .+$/,
         ),
       });
 
@@ -127,7 +127,7 @@ describe("holiday reminder", () => {
       expect(postMessage).toHaveBeenCalledWith({
         channel: "test channel",
         text: expect.stringMatching(
-          /^<!here> Remember that \*Thursday\* is a federal holiday in observance of \*test holiday\*! .+$/,
+          /^Remember that \*Thursday\* is a federal holiday in observance of \*test holiday\*! .+$/,
         ),
       });
 
@@ -145,7 +145,7 @@ describe("holiday reminder", () => {
       expect(postMessage).toHaveBeenCalledWith({
         channel: "general",
         text: expect.stringMatching(
-          /^<!here> Remember that \*Thursday\* is a federal holiday in observance of \*Veterans Day\* :salute-you:! .+$/,
+          /^Remember that \*Thursday\* is a federal holiday in observance of \*Veterans Day\* :salute-you:! .+$/,
         ),
       });
 


### PR DESCRIPTION
TTS Slack guidance, linked below, advises against using @here for large-channel messages.

TTS staff gets lots of reminders about upcoming federal holidays. While the work-life balance reminder is appreciated, there's not a clear, compelling reason to break Slack guidance in this context.

This commit removes `@here` from federal holiday reminders.

https://handbook.tts.gsa.gov/tools/slack/notifications-general-communication/#here-and-channel-notifications

Describe what this pull request is doing. If there are associated issues,
cite those here as well.

---

Checklist:

- [ ] Code has been formatted with prettier
- [ ] The [OAuth](https://github.com/18F/charlie/wiki/OAuthEventsAndScopes) wiki
      page has been updated if Charlie needs any new OAuth events or scopes
- [ ] The [Environment Variables](https://github.com/18F/charlie/wiki/EnvironmentVariables)
      wiki page has been updated if new environment variables were introduced
      or existing ones changed
- [ ] The dev wiki has been updated, e.g.:
  - local development processes have changed
  - major development workflows have changed
  - internal utilities or APIs have changed
  - testing or deployment processes have changed
- [ ] If appropriate, the NIST 800-218 documentation has been updated
