### PR TITLE
Add BioArt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ A Slack app bot used within 18F for fun and work.
 
 ### Interactive bots
 
+#### BioArt
+
+Get a piece of art curated by the National Institutes of Health! The
+[BioArt source](https://bioart.niaid.nih.gov/) project is a collection of
+science visuals, including artistic represetnations of bacteria, viruses, cells,
+animals, and more! Just say `bio art` or `bio-art` to get some art!
+
 ##### Coffeemate
 
 Schedule virtual coffees with random teammates! Not sure who you should talk to?

--- a/src/scripts/bio-art.js
+++ b/src/scripts/bio-art.js
@@ -1,12 +1,10 @@
 const {
   cache,
   helpMessage,
-  slack: { postEphemeralResponse },
+  slack: { postFile },
   stats: { incrementStats },
 } = require("../utils");
 const sample = require("../utils/sample");
-
-const identity = { icon_emoji: ":dna:", username: "NIH BioArt" };
 
 const permitted = new Set([
   "fungi",
@@ -95,15 +93,6 @@ const getRandomEntity = async () => {
   };
 };
 
-if (require.main === module) {
-  const main = async () => {
-    const entity = await getRandomEntity();
-
-    console.log(entity);
-  };
-  main();
-}
-
 module.exports = (app) => {
   helpMessage.registerInteractive(
     "Bio-Art",
@@ -111,7 +100,7 @@ module.exports = (app) => {
     "Get a random piece of bio-art from our friends at the National Institutes of Health!",
   );
 
-  app.message(/bio(-)?art/i, async (msg) => {
+  app.message(/bio(-| )?art/i, async (msg) => {
     incrementStats("bio-art");
     const { channel, thread_ts: thread } = msg.message;
 
@@ -120,8 +109,7 @@ module.exports = (app) => {
       .then((r) => r.arrayBuffer())
       .then((a) => Buffer.from(a));
 
-    app.client.filesUploadV2({
-      ...identity,
+    postFile({
       channel_id: channel,
       thread_ts: thread,
       initial_comment: `${entity.title} (art by ${entity.creator})`,

--- a/src/scripts/bio-art.js
+++ b/src/scripts/bio-art.js
@@ -6,6 +6,9 @@ const {
 } = require("../utils");
 const sample = require("../utils/sample");
 
+// The set of ontologies we want. Some of them could be questionable, like
+// human anatomy, so leave those out. Maybe after we review them all more
+// thoroughly, we can decide whether to add more!
 const permitted = new Set([
   "fungi",
   "parasites",
@@ -18,6 +21,7 @@ const permitted = new Set([
 ]);
 
 const get = (url) =>
+  // The BioArt API requires a browser user-agent, so put that in here.
   fetch(url, {
     headers: {
       "User-Agent":
@@ -28,35 +32,56 @@ const get = (url) =>
 const getJSON = (url) => get(url).then((r) => r.json());
 
 const getPermittedOntologyIDs = () =>
+  // The list of ontologu IDs is unlikely to change very often, so cache it
+  // for an hour.
   cache("bio-art ontology id", 60, async () => {
     const allOntologies = await getJSON(
       "https://bioart.niaid.nih.gov/api/ontologies?type=Bioart%20Category",
     );
 
+    // Filter down to just the keys that we've allowed, and then map down to
+    // just the ontology IDs. That's all we need going forward.
     return allOntologies
       .filter(({ ontologyKey }) => permitted.has(ontologyKey.toLowerCase()))
       .map(({ ontologyId }) => ontologyId);
   });
 
 const getEntities = async (ontologyIds) =>
-  cache(`bio-art entities [${ontologyIds.join(",")}]`, 300, async () => {
+  // The list of entities might change more often than the list of ontology IDs,
+  // so we can cache it for a little shorter.
+  cache(`bio-art entities [${ontologyIds.join(",")}]`, 30, async () => {
     const url = new URL("https://bioart.niaid.nih.gov");
 
+    // The search string is part of the URL path, which is unusual. Anyway, it's
+    // these fields and values.
     const search = [
       "type:bioart",
       `license:"Public Domain"`,
       `ontologyid:((${ontologyIds.join(" OR ")}))`,
     ];
 
+    // Now put the whole path together.
     url.pathname = `api/search/${search.join(" AND ")}`;
+
+    // And add a query parameter for the number of entities to fetch. There may
+    // be more entities, but we'll deal with that later.
     url.searchParams.set("size", 100);
 
+    // found is the total number of entities that are responsive to our search,
+    // and hit (initialList) is the first batch of those matches.
     const {
       hits: { found, hit: initialList },
-    } = await getJSON(url.href);
+    } =
+      // Use the URL.href method so it properly escapes the path and search
+      // parameters. This way we don't have to think about it. :)
+      await getJSON(url.href);
 
     const entities = [...initialList];
 
+    // If the number of entities we've received is less than the total number of
+    // entities that match our search, run the search again but add the "start"
+    // query paramemter so we get the next batch. Repeat until we have all of
+    // the responsive entities.
     while (entities.length < found) {
       url.searchParams.set("start", entities.length);
       const {
@@ -65,15 +90,25 @@ const getEntities = async (ontologyIds) =>
       entities.push(...nextList);
     }
 
-    return entities;
+    // And finally, we only want the field data, so map down to just that.
+    return entities.map(({ fields }) => fields);
   });
 
 const getRandomEntity = async () => {
   const ontologyIds = await getPermittedOntologyIDs();
   const entities = await getEntities(ontologyIds);
 
-  const { fields: entity } = sample(entities);
+  const entity = sample(entities);
 
+  // An entity can have multiple variations, each with multiple files. We'll
+  // just grab the first variant. For a given varient, the list of files is a
+  // string of the form:
+  //
+  //    FORMAT:id|FORMAT:id,id,id|FORMAT:id
+  //
+  // Where FORMAT is an image format such as PNG and the ids are a list of file
+  // IDs used to actually fetch the file. So we'll grab the list of PNG file IDs
+  // and then take the last one, for simplicity's sake.
   const file = entity.filesinfo[0]
     .split("|")
     .find((s) => s.startsWith("PNG:"))
@@ -82,10 +117,12 @@ const getRandomEntity = async () => {
     .split(",")
     .pop();
 
+  // Once we have the file ID, we can build up a URL to fetch it.
   const fileUrl = new URL(
     `https://bioart.niaid.nih.gov/api/bioarts/${entity.id[0]}/zip?file-ids=${file}`,
   ).href;
 
+  // All we want from the entity is its title, creator, and download URL.
   return {
     title: entity.title.pop(),
     creator: entity.creator.pop(),
@@ -105,11 +142,14 @@ module.exports = (app) => {
     const { channel, thread_ts: thread } = msg.message;
 
     try {
+      // Get an entity
       const entity = await getRandomEntity();
+      // Get its image file as a buffer
       const file = await get(entity.fileUrl)
         .then((r) => r.arrayBuffer())
         .then((a) => Buffer.from(a));
 
+      // Post that sucker to Slack.
       postFile({
         channel_id: channel,
         thread_ts: thread,

--- a/src/scripts/bio-art.js
+++ b/src/scripts/bio-art.js
@@ -1,0 +1,137 @@
+const {
+  cache,
+  helpMessage,
+  slack: { postEphemeralResponse },
+  stats: { incrementStats },
+} = require("../utils");
+const sample = require("../utils/sample");
+
+const identity = { icon_emoji: ":dna:", username: "NIH BioArt" };
+
+const permitted = new Set([
+  "fungi",
+  "parasites",
+  "animals",
+  "arthropods",
+  "bacteria",
+  "cells and organelles",
+  "plants",
+  "viruses",
+]);
+
+const get = (url) =>
+  fetch(url, {
+    headers: {
+      "User-Agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:132.0) Gecko/20100101 Firefox/132.0",
+    },
+  });
+
+const getJSON = (url) => get(url).then((r) => r.json());
+
+const getPermittedOntologyIDs = () =>
+  cache("bio-art ontology id", 60, async () => {
+    const allOntologies = await getJSON(
+      "https://bioart.niaid.nih.gov/api/ontologies?type=Bioart%20Category",
+    );
+
+    return allOntologies
+      .filter(({ ontologyKey }) => permitted.has(ontologyKey.toLowerCase()))
+      .map(({ ontologyId }) => ontologyId);
+  });
+
+const getEntities = async (ontologyIds) =>
+  cache(`bio-art entities [${ontologyIds.join(",")}]`, 300, async () => {
+    const url = new URL("https://bioart.niaid.nih.gov");
+
+    const search = [
+      "type:bioart",
+      `license:"Public Domain"`,
+      `ontologyid:((${ontologyIds.join(" OR ")}))`,
+    ];
+
+    url.pathname = `api/search/${search.join(" AND ")}`;
+    url.searchParams.set("size", 100);
+
+    const {
+      hits: { found, hit: initialList },
+    } = await getJSON(url.href);
+
+    const entities = [...initialList];
+
+    while (entities.length < found) {
+      url.searchParams.set("start", entities.length);
+      const {
+        hits: { hit: nextList },
+      } = await getJSON(url.href); // eslint-disable-line no-await-in-loop
+      entities.push(...nextList);
+    }
+
+    return entities;
+  });
+
+const getRandomEntity = async () => {
+  const ontologyIds = await getPermittedOntologyIDs();
+  const entities = await getEntities(ontologyIds);
+
+  const { fields: entity } = sample(entities);
+
+  const file = entity.filesinfo[0]
+    .split("|")
+    .find((s) => s.startsWith("PNG:"))
+    .split(":")
+    .pop()
+    .split(",")
+    .pop();
+
+  const fileUrl = new URL(
+    `https://bioart.niaid.nih.gov/api/bioarts/${entity.id[0]}/zip?file-ids=${file}`,
+  ).href;
+
+  return {
+    title: entity.title.pop(),
+    creator: entity.creator.pop(),
+    fileUrl,
+  };
+};
+
+if (require.main === module) {
+  const main = async () => {
+    const entity = await getRandomEntity();
+
+    console.log(entity);
+  };
+  main();
+}
+
+module.exports = (app) => {
+  helpMessage.registerInteractive(
+    "Bio-Art",
+    "bio-art",
+    "Get a random piece of bio-art from our friends at the National Institutes of Health!",
+  );
+
+  app.message(/bio(-)?art/i, async (msg) => {
+    incrementStats("bio-art");
+    const { channel, thread_ts: thread } = msg.message;
+
+    const entity = await getRandomEntity();
+    const file = await get(entity.fileUrl)
+      .then((r) => r.arrayBuffer())
+      .then((a) => Buffer.from(a));
+
+    app.client.filesUploadV2({
+      ...identity,
+      channel_id: channel,
+      thread_ts: thread,
+      initial_comment: `${entity.title} (art by ${entity.creator})`,
+      file_uploads: [
+        {
+          file,
+          filename: `${entity.title.toLowerCase()}.png`,
+          alt_text: entity.title,
+        },
+      ],
+    });
+  });
+};

--- a/src/scripts/bio-art.test.js
+++ b/src/scripts/bio-art.test.js
@@ -1,0 +1,290 @@
+const {
+  getApp,
+  utils: {
+    cache,
+    slack: { postFile },
+  },
+} = require("../utils/test");
+
+const script = require("./bio-art");
+
+describe("bio-art", () => {
+  const app = getApp();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("initialization", () => {
+    it("subscribes to messages", async () => {
+      await script(app);
+
+      expect(app.message).toHaveBeenCalledWith(
+        expect.any(RegExp),
+        expect.any(Function),
+      );
+    });
+
+    describe("hears correct messages", () => {
+      let regex;
+      beforeAll(async () => {
+        await script(app);
+        regex = app.message.mock.calls[0][0];
+      });
+
+      it("is case-insensitive", async () => {
+        expect(regex.test("BIO ART")).toBe(true);
+        expect(regex.test("bio ART")).toBe(true);
+        expect(regex.test("BIO art")).toBe(true);
+      });
+
+      it("accepts a dash with no space", async () => {
+        expect(regex.test("bio-art")).toBe(true);
+      });
+
+      it("accepts a space with no dash", async () => {
+        expect(regex.test("bio art")).toBe(true);
+      });
+
+      it("does not accept anything else between 'bio' and 'art'", async () => {
+        expect(regex.test("bio- art")).toBe(false);
+        expect(regex.test("bio -art")).toBe(false);
+        expect(regex.test("bio - art")).toBe(false);
+        expect(regex.test("bio- -art")).toBe(false);
+        expect(regex.test("bio.art")).toBe(false);
+      });
+    });
+  });
+
+  describe("responds to requests for art", () => {
+    let handler;
+
+    const expectedHeaders = {
+      "User-Agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:132.0) Gecko/20100101 Firefox/132.0",
+    };
+
+    const random = jest.spyOn(global.Math, "random");
+
+    beforeEach(async () => {
+      await script(app);
+      handler = app.getHandler();
+
+      cache.mockImplementation(async (name) => {
+        switch (name) {
+          case "bio-art ontology id":
+            return ["one", "two", "three"];
+          case "bio-art entities [one,two,three]":
+            return [
+              {
+                fields: {
+                  id: [1],
+                  title: ["An art"],
+                  creator: ["Zeus"],
+                  filesinfo: ["svg:bob|bmp:george|PNG:image1a,image1b,image1c"],
+                },
+              },
+              {
+                fields: {
+                  id: [2],
+                  title: ["Some art"],
+                  creator: ["Persephone"],
+                  filesinfo: ["svg:bob|bmp:george|PNG:image2a,image2b,image2c"],
+                },
+              },
+              {
+                fields: {
+                  id: [3],
+                  title: ["The art"],
+                  creator: ["Athena"],
+                  filesinfo: ["svg:bob|bmp:george|PNG:image3a,image3b,image3c"],
+                },
+              },
+            ];
+          default:
+            throw new Error(`unmocked cache key: ${name}`);
+        }
+      });
+
+      fetch.mockResolvedValue({
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+      });
+
+      random.mockReturnValue(0);
+    });
+
+    afterAll(() => {
+      random.mockRestore();
+    });
+
+    describe("if there are errors", () => {});
+
+    describe("if there are no errors", () => {
+      describe("populates caches correctly", () => {
+        it("fetches a list of permitted ontology IDs", async () => {
+          await handler({
+            message: { channel: "channel", thread_ts: "thread" },
+          });
+
+          const populator = cache.mock.calls
+            .find(([key]) => key === "bio-art ontology id")
+            .pop();
+
+          fetch.mockResolvedValue({
+            json: jest.fn().mockResolvedValue([
+              { ontologyKey: "bad", ontologyId: 1 },
+              { ontologyKey: "fungi", ontologyId: 2 },
+              { ontologyKey: "plants", ontologyId: 3 },
+              { ontologyKey: "bad", ontologyId: 4 },
+            ]),
+          });
+
+          const ids = await populator();
+
+          expect(ids).toEqual([2, 3]);
+          expect(fetch).toHaveBeenCalledWith(
+            "https://bioart.niaid.nih.gov/api/ontologies?type=Bioart%20Category",
+            { headers: expectedHeaders },
+          );
+        });
+
+        describe("fetches a list of entities for a set of ontology IDs", () => {
+          it("if there is only one page of results", async () => {
+            await handler({
+              message: { channel: "channel", thread_ts: "thread" },
+            });
+
+            const populator = cache.mock.calls
+              .find(([key]) => key.startsWith("bio-art entities"))
+              .pop();
+
+            fetch.mockResolvedValue({
+              json: jest
+                .fn()
+                .mockResolvedValue({ hits: { found: 1, hit: [1] } }),
+            });
+
+            const entities = await populator();
+
+            expect(entities).toEqual([1]);
+
+            // NOTE: The cache callback function captures the list of ontology
+            // IDs when the cache key is created, so the URL here is built based
+            // on the ontology IDs returned by the mocked cache in the "responds
+            // to requests for art" describe block above.
+            expect(fetch).toHaveBeenCalledWith(
+              `https://bioart.niaid.nih.gov/api/search/type:bioart%20AND%20license:%22Public%20Domain%22%20AND%20ontologyid:((one%20OR%20two%20OR%20three))?size=100`,
+              {
+                headers: expectedHeaders,
+              },
+            );
+          });
+
+          it("if there are several pages of results", async () => {
+            await handler({
+              message: { channel: "channel", thread_ts: "thread" },
+            });
+
+            const populator = cache.mock.calls
+              .find(([key]) => key.startsWith("bio-art entities"))
+              .pop();
+
+            let fetchCallCount = 0;
+            fetch.mockImplementation(async () => {
+              fetchCallCount += 1;
+              switch (fetchCallCount) {
+                case 1:
+                  return {
+                    json: jest.fn().mockResolvedValue({
+                      hits: {
+                        found: 250,
+                        hit: [...Array(100)].map((_, i) => i),
+                      },
+                    }),
+                  };
+
+                case 2:
+                  return {
+                    json: jest.fn().mockResolvedValue({
+                      hits: {
+                        found: 250,
+                        hit: [...Array(100)].map((_, i) => 100 + i),
+                      },
+                    }),
+                  };
+
+                case 3:
+                  return {
+                    json: jest.fn().mockResolvedValue({
+                      hits: {
+                        found: 250,
+                        hit: [...Array(50)].map((_, i) => 200 + i),
+                      },
+                    }),
+                  };
+
+                default:
+                  throw new Error(
+                    `unmocked fetch call count: ${fetchCallCount}`,
+                  );
+              }
+            });
+
+            const entities = await populator();
+
+            expect(entities).toEqual([...Array(250)].map((_, i) => i));
+
+            // NOTE: The cache callback function captures the list of ontology
+            // IDs when the cache key is created, so the URL here is built based
+            // on the ontology IDs returned by the mocked cache in the "responds
+            // to requests for art" describe block above.
+            expect(fetch).toHaveBeenCalledWith(
+              `https://bioart.niaid.nih.gov/api/search/type:bioart%20AND%20license:%22Public%20Domain%22%20AND%20ontologyid:((one%20OR%20two%20OR%20three))?size=100`,
+              {
+                headers: expectedHeaders,
+              },
+            );
+            expect(fetch).toHaveBeenCalledWith(
+              `https://bioart.niaid.nih.gov/api/search/type:bioart%20AND%20license:%22Public%20Domain%22%20AND%20ontologyid:((one%20OR%20two%20OR%20three))?size=100&start=100`,
+              {
+                headers: expectedHeaders,
+              },
+            );
+            expect(fetch).toHaveBeenCalledWith(
+              `https://bioart.niaid.nih.gov/api/search/type:bioart%20AND%20license:%22Public%20Domain%22%20AND%20ontologyid:((one%20OR%20two%20OR%20three))?size=100&start=200`,
+              {
+                headers: expectedHeaders,
+              },
+            );
+          });
+        });
+      });
+
+      it("responds with some art", async () => {
+        random.mockReturnValue(0);
+
+        await handler({ message: { channel: "channel", thread_ts: "thread" } });
+
+        // We fetch the correct file
+        expect(fetch).toHaveBeenCalledWith(
+          `https://bioart.niaid.nih.gov/api/bioarts/1/zip?file-ids=image1c`,
+          { headers: expectedHeaders },
+        );
+
+        // And we post it to Slack
+        expect(postFile).toHaveBeenCalledWith({
+          channel_id: "channel",
+          thread_ts: "thread",
+          initial_comment: "An art (art by Zeus)",
+          file_uploads: [
+            {
+              file: expect.any(Buffer),
+              filename: "an art.png",
+              alt_text: "An art",
+            },
+          ],
+        });
+      });
+    });
+  });
+});

--- a/src/scripts/bio-art.test.js
+++ b/src/scripts/bio-art.test.js
@@ -80,28 +80,22 @@ describe("bio-art", () => {
           case "bio-art entities [one,two,three]":
             return [
               {
-                fields: {
-                  id: [1],
-                  title: ["An art"],
-                  creator: ["Zeus"],
-                  filesinfo: ["svg:bob|bmp:george|PNG:image1a,image1b,image1c"],
-                },
+                id: [1],
+                title: ["An art"],
+                creator: ["Zeus"],
+                filesinfo: ["svg:bob|bmp:george|PNG:image1a,image1b,image1c"],
               },
               {
-                fields: {
-                  id: [2],
-                  title: ["Some art"],
-                  creator: ["Persephone"],
-                  filesinfo: ["svg:bob|bmp:george|PNG:image2a,image2b,image2c"],
-                },
+                id: [2],
+                title: ["Some art"],
+                creator: ["Persephone"],
+                filesinfo: ["svg:bob|bmp:george|PNG:image2a,image2b,image2c"],
               },
               {
-                fields: {
-                  id: [3],
-                  title: ["The art"],
-                  creator: ["Athena"],
-                  filesinfo: ["svg:bob|bmp:george|PNG:image3a,image3b,image3c"],
-                },
+                id: [3],
+                title: ["The art"],
+                creator: ["Athena"],
+                filesinfo: ["svg:bob|bmp:george|PNG:image3a,image3b,image3c"],
               },
             ];
           default:
@@ -171,9 +165,9 @@ describe("bio-art", () => {
               .pop();
 
             fetch.mockResolvedValue({
-              json: jest
-                .fn()
-                .mockResolvedValue({ hits: { found: 1, hit: [1] } }),
+              json: jest.fn().mockResolvedValue({
+                hits: { found: 1, hit: [{ fields: 1 }] },
+              }),
             });
 
             const entities = await populator();
@@ -208,7 +202,7 @@ describe("bio-art", () => {
                     json: jest.fn().mockResolvedValue({
                       hits: {
                         found: 250,
-                        hit: [...Array(100)].map((_, i) => i),
+                        hit: [...Array(100)].map((_, i) => ({ fields: i })),
                       },
                     }),
                   };
@@ -218,7 +212,9 @@ describe("bio-art", () => {
                     json: jest.fn().mockResolvedValue({
                       hits: {
                         found: 250,
-                        hit: [...Array(100)].map((_, i) => 100 + i),
+                        hit: [...Array(100)].map((_, i) => ({
+                          fields: 100 + i,
+                        })),
                       },
                     }),
                   };
@@ -228,7 +224,9 @@ describe("bio-art", () => {
                     json: jest.fn().mockResolvedValue({
                       hits: {
                         found: 250,
-                        hit: [...Array(50)].map((_, i) => 200 + i),
+                        hit: [...Array(50)].map((_, i) => ({
+                          fields: 200 + i,
+                        })),
                       },
                     }),
                   };

--- a/src/utils/slack.js
+++ b/src/utils/slack.js
@@ -120,6 +120,12 @@ const postEphemeralResponse = async (toMsg, message, config = process.env) => {
   );
 };
 
+const postFile = async (message, { SLACK_TOKEN } = process.env) =>
+  defaultClient.filesUploadV2({
+    ...message,
+    token: SLACK_TOKEN,
+  });
+
 const postMessage = async (message, { SLACK_TOKEN } = process.env) =>
   defaultClient.chat.postMessage({
     ...message,
@@ -154,6 +160,7 @@ module.exports = {
   getSlackUsersInConversation,
   postEphemeralMessage,
   postEphemeralResponse,
+  postFile,
   postMessage,
   sendDirectMessage,
   setClient,


### PR DESCRIPTION
This PR adds a new Charlie listener for `bio-art`, `bio art`, or `bioart` that queries the [NIH BioArt](https://bioart.niaid.nih.gov/) API and fetches a random image. The image is then posted to Slack along with the art title and the name of the creator. For example:

![image (1)](https://github.com/user-attachments/assets/27b94407-95db-4ae0-95ba-13ada2f84115)

There is a new OAuth scope required: `files.write`. I will update Charlie's configuration and the wiki after this PR is approved and before merging it.

---

Checklist:

- [x] Code has been formatted with prettier
- [ ] The [OAuth](https://github.com/18F/charlie/wiki/OAuthEventsAndScopes) wiki
      page has been updated if Charlie needs any new OAuth events or scopes
- ~The [Environment Variables](https://github.com/18F/charlie/wiki/EnvironmentVariables)
      wiki page has been updated if new environment variables were introduced
      or existing ones changed~
- ~The dev wiki has been updated, e.g.:~
- ~If appropriate, the NIST 800-218 documentation has been updated~
