### PR TITLE
Fixes a couple of bugs related to UTC offsets and day-counting.

### DIFF
--- a/src/scripts/evermarch.js
+++ b/src/scripts/evermarch.js
@@ -6,13 +6,13 @@
 
 const moment = require("moment-timezone");
 
-const march1 = moment.tz("2020-03-01T00:00:00Z", "America/New_York");
+const march1 = moment.tz("2020-03-01T00:00:00", "America/New_York");
 
 module.exports = (robot) => {
   robot.message(/evermarch/i, ({ message, say }) => {
     const now = moment.tz("America/New_York");
 
-    const days = Math.ceil(moment.duration(now.diff(march1)).as("days"));
+    const days = now.diff(march1, "days") + 1;
 
     say({
       icon_emoji: ":calendar-this-is-fine:",

--- a/src/scripts/evermarch.test.js
+++ b/src/scripts/evermarch.test.js
@@ -1,3 +1,4 @@
+const moment = require("moment-timezone");
 const { getApp } = require("../utils/test");
 const evermarch = require("./evermarch");
 
@@ -26,11 +27,9 @@ describe("The Evermarch", () => {
   });
 
   it("is correct starting March 2, 2020", () => {
-    // Go very slightly ahead of midnight because at exactly midnight, the diff
-    // rounds to exactly one day, so the ceil() logic doesn't yet count it as an
-    // extra day. But a millisecond later, it will. This seems fine. Millisecond
-    // precision is plenty.
-    jest.setSystemTime(Date.parse("2020-03-02T00:00:01Z"));
+    jest.setSystemTime(
+      moment.tz("2020-03-02T00:00:00", "America/New_York").toDate(),
+    );
 
     const message = {
       message: { thread_ts: "thread timestamp" },
@@ -48,12 +47,52 @@ describe("The Evermarch", () => {
     });
   });
 
+  it("is correct at the very end of March 2, 2020", () => {
+    jest.setSystemTime(
+      moment.tz("2020-03-02T23:59:59", "America/New_York").toDate(),
+    );
+
+    const message = {
+      message: { thread_ts: "thread timestamp" },
+      say: jest.fn(),
+    };
+
+    evermarch(app);
+    const handler = app.getHandler();
+    handler(message);
+
+    expect(message.say).toHaveBeenCalledWith({
+      icon_emoji: ":calendar-this-is-fine:",
+      text: "Today is March 2, 2020, in the Evermarch reckoning.",
+      thread_ts: "thread timestamp",
+    });
+  });
+
+  it("is correct at the very start of March 3, 2020", () => {
+    jest.setSystemTime(
+      moment.tz("2020-03-03T00:00:00", "America/New_York").toDate(),
+    );
+
+    const message = {
+      message: { thread_ts: "thread timestamp" },
+      say: jest.fn(),
+    };
+
+    evermarch(app);
+    const handler = app.getHandler();
+    handler(message);
+
+    expect(message.say).toHaveBeenCalledWith({
+      icon_emoji: ":calendar-this-is-fine:",
+      text: "Today is March 3, 2020, in the Evermarch reckoning.",
+      thread_ts: "thread timestamp",
+    });
+  });
+
   it("is correct in the further future from March 1, 2020", () => {
-    // Go very slightly ahead of midnight because at exactly midnight, the diff
-    // rounds to exactly one day, so the ceil() logic doesn't yet count it as an
-    // extra day. But a millisecond later, it will. This seems fine. Millisecond
-    // precision is plenty.
-    jest.setSystemTime(Date.parse("2024-10-15T00:00:01Z"));
+    jest.setSystemTime(
+      moment.tz("2024-10-15T01:00:00", "America/New_York").toDate(),
+    );
 
     const message = {
       message: { thread_ts: "thread timestamp" },
@@ -72,7 +111,9 @@ describe("The Evermarch", () => {
   });
 
   it("is gets to March 2020, 2020, on the expected date", () => {
-    jest.setSystemTime(Date.parse("2025-09-10T12:00:00Z"));
+    jest.setSystemTime(
+      moment.tz("2025-09-10T00:00:00", "America/New_York").toDate(),
+    );
 
     const message = {
       message: { thread_ts: "thread timestamp" },


### PR DESCRIPTION
The Evermarch script mistakenly calculated time from March 1, 2020, midnight UTC, instead of midnight America/New_York as intended. Additionally, it was calculating the time difference in milliseconds and then dividing that into a number of days, which meant it was not accounting for leap years or DST.

---

Checklist:

- [x] Code has been formatted with prettier

N/A:
- The [OAuth](https://github.com/18F/charlie/wiki/OAuthEventsAndScopes) wiki
      page has been updated if Charlie needs any new OAuth events or scopes
- The [Environment Variables](https://github.com/18F/charlie/wiki/EnvironmentVariables)
      wiki page has been updated if new environment variables were introduced
      or existing ones changed
- The dev wiki has been updated, e.g.:
  - local development processes have changed
  - major development workflows have changed
  - internal utilities or APIs have changed
  - testing or deployment processes have changed
- If appropriate, the NIST 800-218 documentation has been updated
