### PR TITLE
Improve q-expand data validation

### DIFF
--- a/config/q-expand.csv
+++ b/config/q-expand.csv
@@ -1179,7 +1179,7 @@ Q1BA,Division 1
 Q1BB,Division 2
 Q1BBA,Branch A
 Q1BBB,Branch B
-Q2,"Deputy Commissioner/Director,"
+Q2,"Deputy Commissioner/Director"
 Q2A,Office of TTS Delivery
 Q2A0A,Technology Operations Division
 Q2AA,Office of Solutions

--- a/src/scripts/q-expand.test.js
+++ b/src/scripts/q-expand.test.js
@@ -245,8 +245,8 @@ describe("q-expand csv data", () => {
     }
   });
 
-  it("is formatted correctly", async () =>
-    new Promise((resolve) => {
+  it("is formatted correctly", async () => {
+    const invalidCount = await new Promise((resolve) => {
       const rows = [];
 
       fs.createReadStream("config/q-expand.csv")
@@ -255,9 +255,15 @@ describe("q-expand csv data", () => {
           rows.push(row);
         })
         .on("end", () => {
-          const invalid = rows.filter((row) => row.length !== 2);
-          expect(invalid.length).toBe(0);
-          resolve();
+          const invalid = rows.filter(
+            (row) =>
+              row.length !== 2 ||
+              row.filter((column) => column.endsWith(",")).length > 0,
+          );
+          resolve(invalid.length);
         });
-    }));
+    });
+
+    expect(invalidCount).toBe(0);
+  });
 });


### PR DESCRIPTION
#577 included data with a trailing comma. The comma was present in the source data, so this adds a check to not allow trailing commas in any values.

Confirmed that the additional validation fails as expected in https://github.com/18F/charlie/actions/runs/16997197191/job/48190665972

---

Checklist:

- [x] Code has been formatted with prettier
- [x] The [OAuth](https://github.com/18F/charlie/wiki/OAuthEventsAndScopes) wiki
      page has been updated if Charlie needs any new OAuth events or scopes
- [x] The [Environment Variables](https://github.com/18F/charlie/wiki/EnvironmentVariables)
      wiki page has been updated if new environment variables were introduced
      or existing ones changed
- [x] The dev wiki has been updated, e.g.:
  - local development processes have changed
  - major development workflows have changed
  - internal utilities or APIs have changed
  - testing or deployment processes have changed
- [x] If appropriate, the NIST 800-218 documentation has been updated